### PR TITLE
Improve BBDD v2 layout responsiveness

### DIFF
--- a/index-bbddv2.html
+++ b/index-bbddv2.html
@@ -1,1 +1,632 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link rel="manifest" href="./manifest.json">
+  <meta name="theme-color" content="#7d3cff">
+  <title>BBDD — Mobile V3</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#0b0f19; --ink:#e9eef7; --muted:#9aa3b2; --accent:#7d3cff; --accent2:#9a74ff;
+      --card:#101726; --chip:#17203a; --border:#1d2743; --shadow:0 12px 28px rgba(0,0,0,.35);
+      --tap:44px; --r:14px; --actionsw:264px;
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{height:100%;}
+    body{
+      margin:0;
+      background:linear-gradient(180deg,#0b0f19 0%,#0d1324 100%);
+      color:var(--ink);
+      font:15px/1.4 "Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      -webkit-font-smoothing:antialiased;
+    }
 
+    a{color:inherit}
+    button,input,select{font:inherit}
+    select,button{cursor:pointer}
+
+    .hidden{display:none !important}
+
+    /* Overlay */
+    #bbdd-overlay{
+      position:fixed; inset:0; z-index:80;
+      background:rgba(4,6,12,.6);
+      backdrop-filter:blur(18px) saturate(120%);
+      -webkit-backdrop-filter:blur(18px) saturate(120%);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:clamp(10px,2vh,20px);
+    }
+    .bbdd-panel{
+      width:min(960px,100%);
+      height:min(100dvh,960px);
+      background:rgba(16,23,38,.86);
+      border:1px solid rgba(125,60,255,.25);
+      border-radius:18px;
+      display:flex;
+      flex-direction:column;
+      overflow:hidden;
+      position:relative;
+      box-shadow:0 18px 44px rgba(0,0,0,.45);
+    }
+
+    header.appbar{
+      position:sticky;
+      top:0;
+      z-index:20;
+      padding:14px clamp(14px,4vw,26px) 10px;
+      background:linear-gradient(180deg,rgba(14,20,35,.98),rgba(14,20,35,.82));
+      border-bottom:1px solid rgba(125,60,255,.22);
+    }
+    header.appbar .top-row{display:flex;flex-wrap:wrap;gap:12px;margin-bottom:8px;align-items:flex-start;}
+    header.appbar .top-row .primary{display:flex;align-items:flex-start;gap:12px;flex:1 1 260px;min-width:0;flex-wrap:wrap;}
+    header.appbar .top-row .primary .btn.icon{flex-shrink:0;}
+    header.appbar .title-wrap{flex:1 1 auto;min-width:0;}
+    header.appbar .title{font-weight:800;font-size:1.06rem;}
+    header.appbar .sub{font-size:.78rem;color:var(--muted);margin-top:2px;}
+    header.appbar .row-actions{display:flex;align-items:center;gap:8px;margin-left:auto;flex-wrap:wrap;min-width:0;}
+    header.appbar .row-actions .btn{white-space:nowrap;}
+
+    .btn{
+      appearance:none;
+      border:1px solid rgba(125,60,255,.25);
+      background:var(--chip);
+      color:var(--ink);
+      min-height:var(--tap);
+      border-radius:12px;
+      padding:10px 14px;
+      font-weight:600;
+      transition:background .2s,border-color .2s,transform .2s;
+    }
+    .btn:hover{border-color:var(--accent2);background:rgba(125,60,255,.16);}
+    .btn.icon{width:var(--tap);display:grid;place-items:center;padding:0;font-size:18px;}
+    .btn.primary{background:linear-gradient(135deg,var(--accent),var(--accent2));border:none;box-shadow:0 10px 30px rgba(125,60,255,.35);}
+    .btn.primary[disabled]{opacity:.55;cursor:progress;box-shadow:none;}
+
+    details.guide{
+      margin:12px 0;
+      border:1px solid rgba(157,167,200,.25);
+      border-radius:14px;
+      background:rgba(18,27,46,.88);
+      padding:10px 14px;
+      box-shadow:0 12px 28px rgba(0,0,0,.3);
+    }
+    details.guide summary{cursor:pointer;color:#cfd6f8;font-weight:600;}
+    details.guide ul{margin:10px 0 0 18px;color:var(--muted);padding:0 0 4px 0;}
+
+    .tools{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin:10px 0 2px;}
+    .field{flex:1 1 220px;display:flex;align-items:center;gap:8px;background:rgba(18,26,44,.92);border:1px solid rgba(125,60,255,.16);border-radius:12px;padding:0 12px;min-height:42px;min-width:0;}
+    .field input{flex:1;min-width:0;background:transparent;border:0;outline:0;color:var(--ink);font-size:15px;}
+    .left-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+    .indicator{font-size:.78rem;color:#ffd166;display:flex;align-items:center;gap:6px;}
+    .indicator.hidden{display:none!important;}
+
+    #bbdd-ai{position:relative;}
+    #ai-sparkle{position:absolute;inset:-6px;pointer-events:none;background:radial-gradient(circle at top,var(--accent2),transparent 60%);opacity:0;animation:pulse 1.6s infinite;}
+    .ai-loading #ai-sparkle{opacity:1;}
+    @keyframes pulse{0%,100%{opacity:.1;}50%{opacity:.45;}}
+
+    main{
+      flex:1;
+      overflow:auto;
+      padding:0 clamp(12px,4vw,28px) clamp(110px,12vh,180px);
+      position:relative;
+      scroll-behavior:smooth;
+    }
+
+    .thead{display:flex;align-items:center;justify-content:space-between;color:var(--muted);font-size:.78rem;margin:6px 2px 0;gap:8px;}
+    .thead .label{flex:1 1 auto;min-width:0;}
+    .thead .add{min-height:36px;padding:0 12px;border-radius:10px;background:rgba(125,60,255,.16);border-color:rgba(125,60,255,.4);}
+
+    #table-wrap{position:relative;}
+    #bbdd-table{width:100%;border-collapse:collapse;}
+    #bbdd-table colgroup,#bbdd-table thead{display:none;}
+    #bbdd-table tbody tr{display:table-row;}
+    #bbdd-table td{border:0;padding:0;background:transparent;}
+
+    .item{position:relative;margin:10px 0;height:auto;border-radius:16px;overflow:hidden;touch-action:pan-y;}
+    .item .actions{position:absolute;inset:0;display:flex;align-items:center;justify-content:flex-end;gap:8px;padding-right:8px;background:linear-gradient(90deg,transparent 40%,rgba(10,14,28,.88) 100%);}
+    .item .act{min-width:96px;height:38px;border-radius:11px;border:1px solid rgba(125,60,255,.35);background:rgba(32,38,66,.85);color:#fff;font-size:.82rem;font-weight:700;display:flex;align-items:center;justify-content:center;gap:6px;box-shadow:0 6px 18px rgba(0,0,0,.35);}
+    .item .act.modify{border-color:#2b8fdb;background:rgba(26,48,78,.85);}
+    .item .act.improve{border-color:#8c5cff;background:rgba(39,28,78,.85);}
+    .item .act.del{border-color:#e74c3c;background:rgba(64,20,28,.9);}
+
+    .slidable{position:relative;display:flex;align-items:flex-start;gap:12px;background:var(--card);border:1px solid rgba(125,60,255,.22);border-radius:16px;padding:14px;transition:transform .18s ease;will-change:transform;box-shadow:var(--shadow);}    
+    .slidable .mark{width:6px;border-radius:999px;background:linear-gradient(180deg,#2a7fff,#7d3cff);align-self:stretch;}
+    .slidable .content{flex:1;min-width:0;display:flex;flex-direction:column;gap:12px;}
+    .row-main{display:flex;align-items:center;gap:10px;}
+    .drag-handle{width:28px;height:36px;border-radius:10px;background:rgba(255,255,255,.04);border:1px solid rgba(125,60,255,.18);display:flex;align-items:center;justify-content:center;color:#8b95b5;font-weight:700;font-size:1.1rem;user-select:none;cursor:grab;}
+    .drag-handle .handle{pointer-events:none;}
+    .task-input{flex:1;min-width:0;background:rgba(255,255,255,.02);border:1px solid rgba(125,60,255,.24);border-radius:12px;padding:10px 12px;color:var(--ink);}
+    .task-input.ai-updated{border-color:#71e6b5;box-shadow:0 0 0 1px rgba(113,230,181,.35);}
+    .task-input::placeholder{color:rgba(233,238,247,.35);}
+
+    .meta{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));background:rgba(255,255,255,.02);border:1px solid rgba(125,60,255,.18);border-radius:12px;padding:10px;opacity:0;max-height:0;overflow:hidden;transition:opacity .18s ease,max-height .18s ease;}
+    .item.expanded .meta{opacity:1;max-height:320px;}
+    .meta label{display:flex;flex-direction:column;font-size:.74rem;color:var(--muted);gap:6px;}
+    .meta select,.meta input{width:100%;background:rgba(14,24,40,.9);border:1px solid rgba(125,60,255,.22);border-radius:10px;min-height:36px;padding:6px 10px;color:var(--ink);}
+    .meta input::placeholder{color:rgba(233,238,247,.3);}
+
+    .diff-chip,.more{
+      height:40px;
+      width:42px;
+      border-radius:11px;
+      border:1px solid rgba(125,60,255,.22);
+      background:rgba(22,30,50,.92);
+      color:var(--ink);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:0 10px;
+    }
+    .diff-chip{width:auto;gap:8px;padding:0 14px;font-weight:600;font-size:.86rem;}
+    .diff-chip .dot{width:10px;height:10px;border-radius:99px;background:#8a93a7;}
+    .diff-chip[data-v="Fácil"] .dot{background:#2ecc71;}
+    .diff-chip[data-v="Media"] .dot{background:#f1c40f;}
+    .diff-chip[data-v="Difícil"] .dot{background:#e74c3c;}
+
+    .hidden-feedback{display:none!important;}
+
+    .more{font-size:20px;}
+    .item.expanded .more{background:rgba(125,60,255,.2);border-color:rgba(125,60,255,.5);}
+
+    .bbdd-footer{
+      position:absolute;
+      inset:auto 0 0 0;
+      padding:14px clamp(14px,4vw,24px) calc(env(safe-area-inset-bottom)+18px);
+      background:linear-gradient(180deg,rgba(11,16,28,.1) 0%,rgba(11,16,28,.88) 45%,rgba(11,16,28,.98) 100%);
+      display:flex;
+      align-items:center;
+      gap:10px;
+    }
+    #status-msg{flex:1;color:#9ff7cc;font-size:.82rem;transition:opacity .2s;}
+    .bbdd-footer .btn{min-height:42px;}
+
+    #table-spinner{
+      position:absolute;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      flex-direction:column;
+      gap:12px;
+      background:rgba(8,12,24,.85);
+      border-radius:18px;
+      color:var(--ink);
+      font-weight:600;
+      z-index:10;
+    }
+    #table-spinner .ring{
+      width:36px;height:36px;border-radius:50%;
+      border:3px solid rgba(125,60,255,.18);
+      border-top-color:var(--accent2);
+      animation:spin .9s linear infinite;
+    }
+    #ai-overlay{position:absolute;inset:0;display:none;align-items:center;justify-content:center;background:rgba(7,12,26,.82);color:#cfd7ff;font-weight:600;z-index:12;gap:10px;}
+    #ai-overlay .spark{font-size:1.4rem;animation:twinkle 1.6s ease-in-out infinite;}
+    .ai-loading #ai-overlay{display:flex;}
+    @keyframes twinkle{0%,100%{opacity:.4;transform:scale(1);}50%{opacity:1;transform:scale(1.2);}}
+    @keyframes spin{to{transform:rotate(360deg);}}
+
+    #add-row-dup{display:none;align-items:center;justify-content:center;padding:0 12px;}
+
+    /* Responsive */
+    @media (min-width:780px){
+      body{background:#060912;}
+      header.appbar{padding:18px 40px 14px;}
+      main{padding:10px 40px 180px;}
+      .item{margin:12px 0;}
+      .slidable{gap:16px;padding:18px;}
+      .meta{grid-template-columns:repeat(3,minmax(160px,1fr));}
+    }
+
+    @media (max-width:720px){
+      header.appbar .top-row .primary .title-wrap{flex-basis:100%;}
+      header.appbar .top-row .row-actions{width:100%;margin-left:0;justify-content:flex-end;}
+      header.appbar .top-row .row-actions .btn{flex:1;min-width:0;}
+      header.appbar .top-row .primary{width:100%;}
+      .tools{flex-direction:column;align-items:stretch;gap:8px;}
+      .left-tools{width:100%;justify-content:flex-start;}
+      .field{width:100%;}
+      #bbdd-ai{width:100%;}
+      #add-row{display:none;}
+      #add-row-dup{display:inline-flex;}
+    }
+
+    @media (max-width:520px){
+      .slidable{padding:12px 12px 14px;}
+      .task-input{font-size:.94rem;}
+      .meta{grid-template-columns:repeat(auto-fit,minmax(120px,1fr));}
+      .btn.primary{min-width:160px;}
+    }
+
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0;}
+  </style>
+</head>
+<body>
+  <div id="bbdd-overlay" class="bbdd-overlay hidden">
+    <div class="bbdd-panel">
+      <header class="appbar">
+        <div class="top-row">
+          <div class="primary">
+            <button class="btn icon" id="bbdd-back" title="Volver">⟵</button>
+            <div class="title-wrap">
+              <div class="title">Conf BBDD &amp; Daily Quest</div>
+              <div class="sub">Lista compacta • Swipe a la izquierda para acciones • Tap en dificultad para ciclarla</div>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button id="bbdd-confirm" class="btn primary">Confirmar cambios ✓</button>
+          </div>
+        </div>
+
+        <details class="guide" open>
+          <summary>📌 Cómo escribir buenas Tasks + usar IA</summary>
+          <ul>
+            <li>Completables en un día, claras y medibles.</li>
+            <li>Evitá vaguedades. Mejor: “Preparar comida saludable” / “Meditar 10’”.</li>
+            <li>Deslizá y usá <strong>Mejorar</strong> o <strong>Modificar</strong> con IA para afinar la task.</li>
+          </ul>
+        </details>
+
+        <div class="tools">
+          <div class="left-tools">
+            <button id="add-row" class="btn">＋ Fila</button>
+            <span id="dirty-indicator" class="indicator hidden">● Cambios sin guardar</span>
+          </div>
+          <div class="field" style="flex:1">
+            <span aria-hidden="true">🔎</span>
+            <input id="search" type="search" placeholder="Filtrar tareas…" autocomplete="off" />
+          </div>
+          <button id="bbdd-ai" class="btn" title="Generar con IA">✨ AI (Beta)<span id="ai-sparkle"></span></button>
+        </div>
+
+        <div class="thead">
+          <span class="label">Task</span>
+          <button id="add-row-dup" class="btn add" type="button">＋</button>
+        </div>
+      </header>
+
+      <main>
+        <section id="table-wrap">
+          <div id="table-spinner" aria-live="polite" aria-busy="true">
+            <span class="ring" aria-hidden="true"></span>
+            <span class="txt">Cargando tus tareas…</span>
+          </div>
+          <div id="ai-overlay" role="status" aria-live="polite">
+            <span class="spark">✨</span>
+            <span>Generando tareas con IA…</span>
+          </div>
+          <table id="bbdd-table" aria-label="Tabla de tareas">
+            <colgroup>
+              <col class="col-pilar" />
+              <col class="col-rasgo" />
+              <col class="col-stat" />
+              <col class="col-task" />
+              <col class="col-dificultad" />
+              <col class="col-feedback" />
+              <col class="col-eliminar" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th>Pilar</th>
+                <th>Rasgo</th>
+                <th>Stat</th>
+                <th>Task</th>
+                <th>Dificultad</th>
+                <th>Feedback</th>
+                <th>Eliminar</th>
+              </tr>
+            </thead>
+            <tbody id="bbdd-tbody"></tbody>
+          </table>
+        </section>
+      </main>
+
+      <footer class="bbdd-footer">
+        <small id="status-msg"></small>
+        <button id="close-modal" class="btn">Cerrar</button>
+      </footer>
+    </div>
+  </div>
+
+  <script>
+    (function(){
+      const q = new URLSearchParams(location.search);
+      const hasEmail = q.has('email') && q.get('email').trim() !== '';
+      window.BBDD_MODE = hasEmail ? 'page' : 'modal';
+    })();
+  </script>
+  <script src="js/bbdd.js"></script>
+  <script>
+    // Duplica el CTA de sumar fila en mobile
+    (function(){
+      const dup = document.getElementById('add-row-dup');
+      if(!dup) return;
+      dup.addEventListener('click', (e)=>{
+        e.preventDefault();
+        document.getElementById('add-row')?.click();
+      });
+    })();
+
+    (function(){
+      const tbody = document.getElementById('bbdd-tbody');
+      if(!tbody) return;
+
+      const observer = new MutationObserver((mutations)=>{
+        for(const m of mutations){
+          m.addedNodes.forEach(node => {
+            if(node.nodeType === 1 && node.matches('tr')){
+              enhanceRow(node);
+            }
+          });
+        }
+      });
+      observer.observe(tbody,{childList:true});
+
+      // Enhance already rendered rows (por si ya llegaron antes del observer)
+      requestAnimationFrame(()=>{
+        tbody.querySelectorAll('tr').forEach(enhanceRow);
+      });
+
+      let opened = null;
+
+      function enhanceRow(tr){
+        if(tr.dataset.mobileReady === '1') return;
+        const cells = tr.querySelectorAll('td');
+        if(cells.length < 7) return;
+
+        const pilarSel = cells[0].querySelector('select[data-col="0"]');
+        const rasgoSel = cells[1].querySelector('select[data-col="1"]');
+        const statInput = cells[2].querySelector('input[data-col="2"]');
+        const taskInput = cells[3].querySelector('input[data-col="3"]');
+        const diffSelect = cells[4].querySelector('select[data-col="4"]');
+        const feedbackBox = cells[5].querySelector('.feedback');
+        const handle = cells[6].querySelector('.handle');
+
+        if(!taskInput || !diffSelect || !pilarSel || !rasgoSel || !statInput) return;
+
+        const td = document.createElement('td');
+        td.colSpan = 7;
+
+        const item = document.createElement('div');
+        item.className = 'item';
+
+        const actions = document.createElement('div');
+        actions.className = 'actions';
+
+        const btnModify = makeAction('modify','🔁','Modificar', ()=> runAiForRow(tr,'replace'));
+        const btnImprove = makeAction('improve','🪄','Mejorar', ()=> runAiForRow(tr,'improve'));
+        const btnDelete = makeAction('del','🗑️','Eliminar', ()=> deleteRow(tr));
+        actions.append(btnModify, btnImprove, btnDelete);
+
+        const slidable = document.createElement('div');
+        slidable.className = 'slidable shadow';
+
+        const mark = document.createElement('div');
+        mark.className = 'mark';
+
+        const content = document.createElement('div');
+        content.className = 'content';
+
+        const rowMain = document.createElement('div');
+        rowMain.className = 'row-main';
+
+        const drag = document.createElement('span');
+        drag.className = 'drag-handle';
+        if(handle){ drag.append(handle); }
+        else { drag.textContent = '⋮⋮'; }
+
+        taskInput.classList.add('task-input');
+        taskInput.setAttribute('placeholder','Nueva task…');
+
+        rowMain.append(drag, taskInput);
+
+        const diffChip = document.createElement('button');
+        diffChip.type = 'button';
+        diffChip.className = 'diff-chip';
+        diffChip.title = 'Cambiar dificultad';
+        diffChip.innerHTML = '<span class="dot"></span><span class="label"></span>';
+
+        const more = document.createElement('button');
+        more.type = 'button';
+        more.className = 'more';
+        more.title = 'Mostrar columnas';
+        more.textContent = '⋯';
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        meta.append(createMeta('Pilar', pilarSel), createMeta('Rasgo', rasgoSel), createMeta('Stat', statInput));
+
+        content.append(rowMain, meta);
+
+        if(feedbackBox){
+          feedbackBox.classList.add('hidden-feedback');
+          content.append(feedbackBox);
+        }
+
+        slidable.append(mark, content, diffChip, more);
+        item.append(actions, slidable);
+        td.append(item);
+        tr.innerHTML = '';
+        tr.append(td);
+        tr.dataset.mobileReady = '1';
+
+        updateDiff(diffChip, diffSelect.value);
+
+        diffSelect.classList.add('sr-only');
+        diffChip.addEventListener('click', ()=>{
+          cycleDiff(diffSelect);
+          updateDiff(diffChip, diffSelect.value);
+          const ev = new Event('input', { bubbles:true });
+          diffSelect.dispatchEvent(ev);
+          const ev2 = new Event('change', { bubbles:true });
+          diffSelect.dispatchEvent(ev2);
+        });
+        diffSelect.addEventListener('change', ()=> updateDiff(diffChip, diffSelect.value));
+        diffSelect.addEventListener('input', ()=> updateDiff(diffChip, diffSelect.value));
+
+        more.addEventListener('click', (e)=>{
+          e.preventDefault();
+          e.stopPropagation();
+          item.classList.toggle('expanded');
+        });
+
+        makeSwipeable(item, slidable);
+      }
+
+      function makeAction(cls, icon, label, onClick){
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.className = `act ${cls}`;
+        b.innerHTML = `<span>${icon}</span><span>${label}</span>`;
+        b.addEventListener('click', (e)=>{
+          e.preventDefault();
+          e.stopPropagation();
+          closeAll();
+          onClick();
+        });
+        return b;
+      }
+
+      function createMeta(label, control){
+        const wrap = document.createElement('label');
+        wrap.textContent = label;
+        wrap.append(control);
+        return wrap;
+      }
+
+      function updateDiff(chip, value){
+        chip.dataset.v = value || '';
+        chip.querySelector('.label').textContent = value || '—';
+      }
+
+      function cycleDiff(select){
+        const opts = Array.from(select.options).map(o=>o.value).filter(Boolean);
+        if(!opts.length) return;
+        const idx = opts.indexOf(select.value);
+        const next = opts[(idx+1)%opts.length];
+        select.value = next;
+      }
+
+      function makeSwipeable(wrapper, slide){
+        const actions = wrapper.querySelector('.actions');
+        const max = () => actions ? actions.getBoundingClientRect().width + 12 : 0;
+        let startX = 0; let currentX = 0; let dragging = false; let pointerId = null;
+
+        function shouldSkip(target){
+          return target.closest('input, select, textarea, button, .meta');
+        }
+
+        function start(e){
+          const touch = e.touches ? e.touches[0] : e;
+          if(shouldSkip(e.target)) return;
+          dragging = true;
+          pointerId = touch.identifier ?? 'mouse';
+          startX = touch.clientX;
+          currentX = startX;
+          slide.style.transition = 'none';
+        }
+        function move(e){
+          if(!dragging) return;
+          const touchList = e.touches ? [...e.touches] : [e];
+          const touch = touchList.find(t => (t.identifier ?? 'mouse') === pointerId);
+          if(!touch) return;
+          currentX = touch.clientX;
+          let dx = Math.min(0, currentX - startX);
+          const limit = -max();
+          if(dx < limit) dx = limit;
+          slide.style.transform = `translateX(${dx}px)`;
+        }
+        function end(){
+          if(!dragging) return;
+          dragging = false;
+          slide.style.transition = '';
+          const dx = currentX - startX;
+          if(dx < -60){ openRow(wrapper, slide); }
+          else { closeRow(wrapper, slide); }
+          pointerId = null;
+        }
+
+        slide.addEventListener('touchstart', start, {passive:true});
+        slide.addEventListener('touchmove', move, {passive:true});
+        slide.addEventListener('touchend', end, {passive:true});
+        slide.addEventListener('mousedown', (e)=>{ start(e); window.addEventListener('mousemove', move); window.addEventListener('mouseup', upOnce, { once:true }); });
+
+        function upOnce(){ window.removeEventListener('mousemove', move); end(); }
+      }
+
+      function openRow(wrapper, slide){
+        closeAll();
+        const width = wrapper.querySelector('.actions')?.getBoundingClientRect().width || 0;
+        slide.style.transform = `translateX(${-width - 12}px)`;
+        wrapper.classList.add('row-open');
+        opened = wrapper;
+      }
+
+      function closeRow(wrapper, slide){
+        slide.style.transform = 'translateX(0)';
+        wrapper.classList.remove('row-open');
+        if(opened === wrapper) opened = null;
+      }
+
+      function closeAll(){
+        if(!opened) return;
+        const slide = opened.querySelector('.slidable');
+        if(slide) closeRow(opened, slide);
+      }
+
+      document.addEventListener('pointerdown', (e)=>{
+        if(!opened) return;
+        if(opened.contains(e.target)) return;
+        const slide = opened.querySelector('.slidable');
+        if(slide) closeRow(opened, slide);
+      });
+
+      function deleteRow(tr){
+        if(typeof state === 'undefined') return;
+        const idx = Number(tr.dataset.index);
+        if(Number.isNaN(idx)) return;
+        state.rows.splice(idx,1);
+
+        const next = new Set();
+        for(const i of state.aiUpdated){
+          if(i < idx) next.add(i);
+          else if(i > idx) next.add(i - 1);
+        }
+        state.aiUpdated = next;
+
+        markDirty();
+        render();
+      }
+
+      async function runAiForRow(tr, mode){
+        if(typeof state === 'undefined') return;
+        const idx = Number(tr.dataset.index);
+        if(Number.isNaN(idx)) return;
+        const row = state.rows[idx];
+        if(!row) return;
+
+        try{
+          aiLoading(true);
+          const batch = [[normPilar(row[0]||''), cleanRasgo(row[1]||''), (row[2]||''), (row[3]||''), normDiff(row[4]||''), mode]];
+          const results = await aiSendBatch(email, batch);
+          aiApplyResults([idx], results);
+          markDirty();
+          render();
+          toast(mode === 'improve' ? '🪄 Task mejorada con IA' : '🔁 Task modificada con IA');
+        }catch(err){
+          console.error(err);
+          toast('Error al usar IA: ' + err.message, false);
+        }finally{
+          aiLoading(false);
+        }
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restructure the BBDD v2 header so the title and confirm action wrap cleanly on narrow screens while preserving desktop spacing
- update the toolbar and add-row controls to avoid duplicated buttons and let search/AI actions expand on mobile widths

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d69cf058ec8322b39587a765f05b3c