### PR TITLE
Create refactor shadow structure for landing and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,72 @@
+# Gamification Web Landing
 
-# Self-Improvement Web (GitHub Pages)
+## Resumen Ejecutivo
+- `indexv2.html` entrega la landing “Innerbloom” con secciones de overview, modos, features, testimonios, FAQ y CTA hacia signup/login.
+- `signupv2.html` + `js/signupv2.js` componen el alta con carga opcional de avatar y polling al Apps Script antes de redirigir al login.
+- `formsintrov3.html` guía al usuario por el journey inicial sumando XP y genera el payload enviado al worker de onboarding.
+- `loginv2.html` verifica el estado de la base vía worker/WebApp, muestra modales await/not-found y lleva al dashboard cuando está listo.
+- `dashboardv3.html` consume el bundle del worker, pinta métricas, notificaciones, panel de rachas y scheduler, apoyado por los módulos en `js/`.
+- `index-bbdd.html` + `js/bbdd.js` ofrecen la edición detallada de hábitos con controles móviles y soporte de IA.
+- PWA: `manifest.json` define la app “GJ” y `sw.js` precachea la shell aplicando estrategia network-first para HTML.
 
-Este sitio es el punto de entrada al sistema gamificado de autosuperación.
+## Inventario de archivos raíz
 
-## Instrucciones
+| Archivo | Tipo | Acción sugerida | Resumen (≤140) | Interacciones |
+|---------|------|-----------------|----------------|---------------|
+| README.md | Markdown | Mantener | Inventario técnico y roadmap de refactor para la landing gamificada. | — |
+| dashboardv3.html | HTML + JS inline | Refactorizar | Dashboard SPA con métricas, energía, misiones y popups; inicializa panel rachas y worker. | css/dashboardv3.css, css/panel-rachas.overrides.css, css/popups.css, js/dashboardv3.js, js/scheduler-controller.js, js/noti-client.js, js/panel-rachas.js, js/popups.js, sw.js, manifest.json |
+| formsintrov3.html | HTML + JS inline | Refactorizar | Wizard gamificado para captar base inicial y XP; construye payload y envía onboarding al worker. | css/formsintrov2.css, loginv2.html |
+| index-bbdd.html | HTML + CSS/JS inline | Refactorizar | Editor responsivo de BBDD con UI glassmórfica, helpers móviles y extensión de aiApplyResults. | js/bbdd.js, dashboardv3.html, manifest.json |
+| indexv2.html | HTML + JS inline | Refactorizar | Landing Innerbloom con secciones de modos, features, testimonios y carrusel accesible. | css/stylesv3.css, formsintrov3.html, loginv2.html, signupv2.html |
+| loginv2.html | HTML + CSS/JS inline | Refactorizar | Pantalla login con estilo glass, modales await/not-found y flujo polling hacia dashboard worker. | sw.js, manifest.json, dashboardv3.html, signupv2.html, indexv2.html |
+| offline.html | HTML + CSS inline | Refactorizar | Página offline mínima que enlaza dashboard en caché y reutiliza CSS principal. | css/dashboardv3.css, dashboardv3.html |
+| signupv2.html | HTML puro | Ordenar en bloques | Formulario de alta con avatar opcional y modal de estado; delega lógica a signupv2.js. | css/signupv2.css, js/signupv2.js, indexv2.html, loginv2.html, formsintrov3.html |
+| sw.js | JS puro | Ordenar en bloques | Service worker que precachea shell, aplica network-first para HTML y stale-while-revalidate para assets. | loginv2.html, dashboardv3.html, index-bbdd.html, offline.html, css/dashboardv3.css, css/bbdd.css, js/dashboardv3.js, js/scheduler-controller.js, js/scheduler-modal.js, js/scheduler-api.js, js/bbdd.js |
+| manifest.json | JSON | Ordenar en bloques | Manifest PWA que inicia en loginv2, define colores y assets maskable. | loginv2.html, dashboardv3.html, icons/ |
 
-1. Subí esta carpeta a un nuevo repositorio de GitHub.
-2. Activá GitHub Pages desde la pestaña 'Pages' del repo.
-3. Asegurate de reemplazar `WEBAPP_URL` en `main.js` por el URL real de tu WebApp.
+## Carpeta `js/`
 
-🚀 ¡Listo para lanzar!
+| Archivo | Tipo | Acción sugerida | Resumen (≤140) | Interacciones |
+|---------|------|-----------------|----------------|---------------|
+| bbdd.js | JS puro | Ordenar en bloques | Renderiza y sincroniza la tabla de hábitos: fetch API, drag-drop, banderas AI y confirmaciones. | index-bbdd.html, dashboardv3.html, API Worker BBDD |
+| dashboardv3.js | JS puro | Ordenar en bloques | Carga bundle del worker, pinta métricas, maneja flags locales y emite eventos de estado. | dashboardv3.html, js/scheduler-controller.js, js/panel-rachas.js, js/popups.js, sw.js |
+| formsintrov2.js | JS puro | Ordenar en bloques | Versión JS del journey form: rutas por modo, toasts XP y builder de payload GJPayload. | formsintrov3.html, onboarding worker |
+| noti-client.js | JS puro | Ordenar en bloques | Cliente ligero que sincroniza notificaciones del worker, cachea local y maneja dropdown. | dashboardv3.html, meta gj-worker-base |
+| panel-rachas.js | JS puro | Ordenar en bloques | Componente global para panel de rachas con filtros, barras semanales y adaptadores de datos. | dashboardv3.html, css/panel-rachas.overrides.css |
+| popups.js | JS puro | Ordenar en bloques | Gestiona popups gamificados: historial visto, estilos recap, confeti y ACK al backend. | dashboardv3.html, css/popups.css, POPUPS_API |
+| scheduler-api.js | JS puro | Ordenar en bloques | API helper del scheduler: Workers, mark_first_programmed y carga de contexto usuario. | js/scheduler-controller.js, dashboardv3.js |
+| scheduler-controller.js | JS puro | Ordenar en bloques | Orquesta el modal scheduler: obtiene contexto, guarda programación y sincroniza UI/dots. | js/scheduler-modal.js, js/scheduler-api.js, dashboardv3.html |
+| scheduler-modal.js | JS puro | Ordenar en bloques | Web component `<scheduler-modal>` con layout, inputs y eventos open/save/pause/test. | js/scheduler-controller.js |
+| signupv2.js | JS puro | Ordenar en bloques | Gestiona alta: sube avatar a ImgBB, envía Google Form y pollinga estado para redirigir. | signupv2.html, formsintrov3.html, loginv2.html, Google Form |
+
+## Carpeta `css/`
+
+| Archivo | Tipo | Acción sugerida | Resumen (≤140) | Interacciones |
+|---------|------|-----------------|----------------|---------------|
+| bbdd.css | CSS puro | Ordenar en bloques | Hoja canónica del editor BBDD: tokens glass, columnas sticky y tablas accesibles. | index-bbdd.html, sw.js |
+| dashboardv3.css | CSS puro | Ordenar en bloques | Estilos del dashboard: header sticky, columnas flex, cards glass y charts temáticos. | dashboardv3.html, offline.html |
+| formsintrov2.css | CSS puro | Ordenar en bloques | Define HUD fijo, tarjetas hero y chips checklist para el journey onboarding. | formsintrov3.html |
+| panel-rachas.overrides.css | CSS puro | Ordenar en bloques | Overrides para integrar panel de rachas al dashboard: tokens glass y grids responsivas. | dashboardv3.html, js/panel-rachas.js |
+| popups.css | CSS puro | Ordenar en bloques | Estilos del overlay de popups con blur, CTA animado, confeti y layout responsive. | dashboardv3.html, js/popups.js |
+| signupv2.css | CSS puro | Ordenar en bloques | Estiliza signup glass con grid responsiva, modal de estado y spinner reutilizable. | signupv2.html |
+| stylesv3.css | CSS puro | Ordenar en bloques | Hoja de la landing: nav sticky, hero con glows, grids de cards y timeline de pasos. | indexv2.html |
+
+## Flujo sugerido
+1. **Descubrimiento:** La landing presenta el producto, modos de juego y llamadas a crear cuenta o iniciar sesión.
+2. **Signup:** El formulario envía datos al Google Form, sube el avatar y monitorea el procesamiento antes de confirmar al usuario.
+3. **Journey inicial:** El wizard recopila preferencias, calcula XP y envía el payload al worker de onboarding.
+4. **Login:** Se consulta el estado de la base (ready / pending / not found) y se redirige al dashboard cuando corresponde.
+5. **Dashboard:** Se renderiza la experiencia gamificada (XP, energía, radar, misiones, notificaciones, scheduler) usando datos del worker.
+6. **Edición de hábitos:** Desde el dashboard se accede al editor BBDD con controles drag & drop, AI helpers y confirmación de cambios.
+
+## Capacidades PWA
+- `manifest.json` fija start_url, tema y assets maskable para instalación como app.
+- `sw.js` precachea HTML, CSS y JS clave, maneja fallback offline y actualiza cachés obsoletos.
+- Las vistas principales registran el service worker y exponen metadatos de instalación en el login.
+
+## Desarrollo y siguientes pasos
+- Modularizar los archivos HTML con JS inline para facilitar mantenimiento y pruebas.
+- Agrupar estilos reutilizables en utilidades compartidas y documentar tokens visuales.
+- Mantener sincronizados `sw.js` y `manifest.json` al renombrar rutas o assets.
+- Completar la documentación técnica de los workers y endpoints externos usados (Google Forms, Apps Script, POPUPS_API).
+

--- a/refactor/CONTRIBUTING.refactor.md
+++ b/refactor/CONTRIBUTING.refactor.md
@@ -1,0 +1,8 @@
+# Cómo contribuir en la carpeta `refactor/`
+
+1. **No toques los originales.** Toda mejora vive dentro de `refactor/` con el mismo nombre + `.refactor` si es una vista.
+2. **Mantén los comentarios amigables.** Explica qué hace cada bloque y por qué, evitando tecnicismos innecesarios.
+3. **Respeta la estructura.** CSS en `refactor/css`, JS en `refactor/js`, HTML en `refactor/views`.
+4. **Misiones por lote.** Antes de comenzar una tarea, agrega notas en este archivo o en DOCUMENTATION si surgen dudas.
+5. **Pruebas manuales.** Al terminar, abre la vista en el navegador y sigue el flujo original para evitar regresiones.
+6. **TODOs documentados.** Si encuentras algo riesgoso, deja `// TODO:` explicando la mejora propuesta sin implementarla.

--- a/refactor/DOCUMENTATION.refactor.md
+++ b/refactor/DOCUMENTATION.refactor.md
@@ -1,0 +1,26 @@
+# Mapa inicial de la carpeta `refactor/`
+
+> Esta guía explica cómo navegar la "carpeta sombra" sin modificar los archivos originales.
+
+## Vistas
+- `views/indexv2.refactor.html` — Landing principal. Usa `css/stylesv3.css` para visuales y `js/features/landing.js` para el carrusel accesible.
+- `views/loginv2.refactor.html` — Portal de acceso. Usa `css/layout.css` y el módulo `js/features/login.js`.
+
+## Utilidades JS
+- `js/utils/dom.js` — Selectores seguros, escucha de eventos y helpers para manipular atributos sin repetir código.
+- `js/utils/net.js` — Capa muy simple sobre `fetch` para llamadas JSON con timeouts.
+- `js/utils/a11y.js` — Rutinas para foco, anuncios en `aria-live` y ayuda de accesibilidad.
+- `js/utils/constants.js` — Endpoints, claves de almacenamiento y flags compartidos.
+
+## Cómo probar una vista refactorizada
+1. Abrí el archivo `.refactor.html` directo en el navegador (doble clic o `Live Server`).
+2. Verificá que los enlaces sigan apuntando a las rutas originales (`signupv2.html`, `dashboardv3.html`, etc.).
+3. Revisá la consola: no debe haber errores nuevos. Si aparece alguno, anotarlo en TODO.
+4. Compará visualmente con la versión original para asegurar que la UI/UX no cambió.
+
+## Convenciones
+- Comentarios con tono sencillo, como si se lo explicáramos a alguien de 5 años.
+- Archivos CSS con encabezado `/* ==========================================================================`.
+- Módulos JS con encabezado detallando propósito, API pública, dependencias y notas de accesibilidad.
+
+Más vistas y módulos se irán sumando en los siguientes lotes.

--- a/refactor/css/base.css
+++ b/refactor/css/base.css
@@ -1,0 +1,45 @@
+/* ==========================================================================
+   Componente: Base
+   Uso: reglas globales compartidas (reset suave y tipografía)
+   Notas: mantener liviano; cada vista suma sus estilos específicos.
+   ========================================================================== */
+
+:root {
+  /* Paleta base usada en múltiples vistas. */
+  --color-bg-dark: #0b0f19;
+  --color-text-main: #e8eaf2;
+  --color-text-muted: #b9bed1;
+  --font-family-base: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+/* ===== [Base: Reset amigable] =====
+   Le explicamos al navegador que todas las cajas cuentan bordes y padding
+   dentro de su tamaño total para evitar sorpresas de layout. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* ===== [Base: Texto legible] =====
+   Esto asegura que cualquier body que no declare tipografía hereda Rubik. */
+body {
+  margin: 0;
+  font-family: var(--font-family-base);
+  color: var(--color-text-main);
+  background-color: var(--color-bg-dark);
+}
+
+/* ===== [Base: Imágenes amigables] =====
+   Las imágenes nunca se desbordan de su contenedor. */
+img {
+  max-width: 100%;
+  display: block;
+}
+
+/* ===== [Base: Vínculos accesibles] =====
+   Hacemos que los enlaces muestren un enfoque claro al navegar con teclado. */
+a:focus-visible {
+  outline: 3px solid var(--color-text-main);
+  outline-offset: 2px;
+}

--- a/refactor/css/layout.css
+++ b/refactor/css/layout.css
@@ -1,0 +1,376 @@
+/* ==========================================================================
+   Componente: Layout General + Login
+   Uso: estilos compartidos para fondos con orbes y tarjetas glassmórficas.
+   Notas: replica el layout original del login sin cambiar la apariencia.
+   ========================================================================== */
+
+/* ===== [Layout: Tokens del login] =====
+   Valores que antes vivían en el <style> del HTML. */
+:root {
+  --bg: #0b0e14;
+  --card: rgba(255, 255, 255, 0.06);
+  --card-border: rgba(255, 255, 255, 0.08);
+  --text: #e8eaf2;
+  --text-dim: #b9bed1;
+  --accent: #8e6cff;
+  --accent-2: #4ad1ff;
+  --chip: rgba(255, 255, 255, 0.08);
+}
+
+/* ===== [Layout: Fondo con degradés] =====
+   Dibuja el mismo fondo espacial que ya existía en loginv2. */
+body.login-body {
+  background:
+    radial-gradient(1200px 700px at 20% -10%, #251b52 0%, transparent 65%),
+    radial-gradient(900px 600px at 80% 10%, #0a3b53 0%, transparent 60%),
+    var(--bg, #0b0e14);
+  min-height: 100vh;
+}
+
+/* ===== [Layout: Orbes decorativos] =====
+   Son luces desenfocadas que hacen que el fondo se vea mágico. */
+.bg {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.bg .orb {
+  position: absolute;
+  filter: blur(60px);
+  opacity: 0.35;
+  border-radius: 50%;
+}
+
+.bg .orb.a {
+  width: 380px;
+  height: 380px;
+  left: -120px;
+  top: -120px;
+  background: #7c5cff;
+}
+
+.bg .orb.b {
+  width: 420px;
+  height: 420px;
+  right: -140px;
+  top: -60px;
+  background: #25a4ff;
+}
+
+.bg .orb.c {
+  width: 500px;
+  height: 500px;
+  left: 50%;
+  bottom: -220px;
+  transform: translateX(-50%);
+  background: #4f3d91;
+}
+
+/* ===== [Nav: Encabezado pegajoso] =====
+   Mantiene visible la marca y vuelve arriba sin moverse. */
+.nav {
+  position: sticky;
+  top: 0;
+  padding: 18px 24px;
+  text-align: center;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35), transparent);
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.nav a {
+  color: var(--text, #e8eaf2);
+  text-decoration: none;
+}
+
+/* ===== [Layout: Contenedor central] =====
+   Centra la tarjeta de login en pantalla como antes. */
+.wrap {
+  display: grid;
+  place-items: center;
+  padding: 56px 20px 80px;
+}
+
+.card {
+  width: min(720px, 92vw);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.085), rgba(255, 255, 255, 0.05));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 32px 28px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+}
+
+.card h1 {
+  margin: 0 0 10px;
+  font-size: 28px;
+  line-height: 1.25;
+}
+
+.card .sub {
+  margin: 0 0 18px;
+  color: var(--text-dim, #b9bed1);
+}
+
+/* ===== [Form: Campos y botones] =====
+   Mismos estilos para inputs y botones brillantes. */
+.field {
+  margin: 14px 0 16px;
+}
+
+.field label {
+  display: block;
+  font-size: 13px;
+  color: var(--text-dim, #b9bed1);
+  margin: 0 0 6px;
+}
+
+.field input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text, #e8eaf2);
+  outline: none;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.btn {
+  appearance: none;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  cursor: pointer;
+  background: linear-gradient(180deg, #a08bff, #7f60ff);
+  color: #151221;
+  box-shadow: 0 6px 22px rgba(127, 96, 255, 0.35);
+}
+
+.btn.secondary {
+  background: transparent;
+  color: var(--text, #e8eaf2);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.status {
+  margin-top: 10px;
+  min-height: 22px;
+  color: var(--text-dim, #b9bed1);
+  text-align: center;
+}
+
+/* ===== [Spinner: indicador de carga] =====
+   Es el mismo circulito que gira al consultar el backend. */
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-left: 6px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  vertical-align: -3px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ===== [Modal Await: overlay principal] =====
+   Reproduce el contenedor translucido con pasos y ayuda. */
+.wait-shell {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.35));
+  z-index: 1000;
+}
+
+.wait-shell.visible {
+  display: flex;
+}
+
+.wait-shell::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(1200px 800px at 80% 10%, rgba(99, 102, 241, 0.18), transparent 70%),
+    rgba(8, 10, 18, 0.7);
+  backdrop-filter: blur(12px) saturate(115%);
+  -webkit-backdrop-filter: blur(12px) saturate(115%);
+}
+
+.wait-card {
+  position: relative;
+  width: min(900px, 92vw);
+  padding: 28px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(24, 26, 35, 0.9), rgba(24, 26, 35, 0.86));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.55);
+}
+
+.wait-title {
+  margin: 4px 0 8px;
+  font-size: 28px;
+  font-weight: 800;
+}
+
+.wait-sub {
+  margin: 0 0 14px;
+  color: var(--text-dim, #b9bed1);
+}
+
+.wait-tip {
+  margin: 10px 0 18px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-dim, #b9bed1);
+}
+
+.wait-section-title {
+  margin: 10px 0 8px;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  color: var(--text-dim, #b9bed1);
+  text-transform: uppercase;
+}
+
+/* ===== [Modal Await: pasos verticales] =====
+   Lista numerada que explica al usuario qué sigue. */
+.next-steps {
+  list-style: none;
+  margin: 10px 0 18px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  counter-reset: step;
+}
+
+.next-steps li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  pointer-events: none;
+}
+
+.next-steps li::before {
+  content: counter(step);
+  counter-increment: step;
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font: 600 13px/1 system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.wait-minor {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 8px 0 2px;
+}
+
+.wait-minor .ghost {
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 999px;
+  transition: transform 0.08s ease;
+  color: var(--text, #e8eaf2);
+  text-decoration: none;
+}
+
+.wait-minor .ghost:active {
+  transform: scale(0.98);
+}
+
+.wait-card .close {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  z-index: 1;
+}
+
+/* ===== [Modal genérico Not-Found] =====
+   Se basa en el mismo estilo glass para mostrar mensajes de error. */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.35));
+  padding: 32px 16px;
+}
+
+.modal.visible {
+  display: flex;
+}
+
+.modal-card {
+  width: min(650px, 92vw);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.085), rgba(255, 255, 255, 0.05));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 22px 20px;
+  backdrop-filter: blur(10px);
+}
+
+.modal-title {
+  margin: 4px 0 10px;
+  font-size: 24px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+/* ===== [Botones fantasmas reutilizables] ===== */
+.ghost {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text, #e8eaf2);
+  cursor: pointer;
+}
+
+.close {
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: var(--text, #e8eaf2);
+  border-radius: 10px;
+  cursor: pointer;
+}

--- a/refactor/css/stylesv3.css
+++ b/refactor/css/stylesv3.css
@@ -1,0 +1,254 @@
+/* ==========================================================================
+   Componente: Landing Styles v3
+   Uso: estilos completos de la landing indexv2 (se mantiene tal cual).
+   Notas: organiza colores, grids y componentes hero/testimonios.
+   ========================================================================== */
+
+:root{
+  --bg:#0b0f19; --bg-2:#0A0D18; --card:#121829; --ink:#e8ecf1; --muted:#9aa3b2;
+  --accent:#7d3cff; --accent-2:#5c28c2; --line:rgba(255,255,255,.14);
+  --low:#b63a3a; --chill:#2f9d66; --flow:#2f6bb6; --evolve:#7d3cff;
+  --glow-1: rgba(160,110,255,.28);
+  --glow-2: rgba(90,45,190,.28);
+}
+/* Marca en el nav */
+.nav .brand{
+  display:flex; align-items:center; gap:.6rem;
+  color:#fff; text-decoration:none; font-weight:700;
+}
+.nav { background:#0b0f19; }
+
+/* Isotipo */
+.logo-mark{ height:28px; width:auto; display:block; }
+
+/* Ocultar el texto en mobile si querés ultra limpio */
+@media (max-width:640px){
+  .brand-text{ display:none; }
+}
+
+/* Si usás nav claro en alguna vista, fuerza el logo negro */
+.nav.is-light .brand { color:#0b0f19; }
+.nav.is-light .brand .logo-mark { content: url("assets/logo/innerbloom_black.svg"); }
+
+*{box-sizing:border-box}
+html,body{height:100%;margin:0;}
+body{
+  font-family:'Rubik',system-ui,-apple-system,Segoe UI,Inter,Roboto,Arial,sans-serif;
+  background:var(--bg);
+  color:var(--ink);
+  min-height:100vh; overflow-x:hidden; position:relative;
+}
+
+/* ==== DESTELLOS / GLOWS FIJOS (iOS-safe) ==== */
+body::before{
+  content:"";
+  position:fixed; inset:0; z-index:0; pointer-events:none;
+  background:
+    radial-gradient(1100px 700px at 12% 8%, var(--glow-1), transparent 70%) no-repeat,
+    radial-gradient(900px 600px at 88% 0%, var(--glow-2), transparent 70%) no-repeat,
+    linear-gradient(180deg, var(--bg-2) 0%, #0B0F1E 100%);
+  background-position: top left, top right, center;
+  background-size: 1100px 800px, 1200px 900px, cover;
+  transform: translateZ(0);
+}
+/* Destello lila central */
+body::after{
+  content:"";
+  position:fixed; inset:0; z-index:0; pointer-events:none;
+  background:
+    radial-gradient(800px 500px at 50% 18%, rgba(167,139,250,.28), transparent 65%);
+  mix-blend-mode:screen; /* suma luz sin lavar el fondo */
+}
+body > *{ position:relative; z-index:1; }
+
+/* ==== LAYOUT ==== */
+.container{ max-width:1080px; margin:0 auto; padding:0 18px; }
+.container.narrow{ max-width:900px; }
+.section-pad{ padding:64px 0; }
+.center{ text-align:center; }
+
+/* ==== NAV con blur + capa sólida (evita transparencia molesta) ==== */
+.nav{
+  width:100%;
+  background:rgba(18,24,41,.78);            /* capa sólida */
+  backdrop-filter: blur(8px);
+  border-bottom:1px solid var(--line);
+  display:flex; align-items:center; justify-content:space-between;
+  gap:12px; padding:12px 18px; position:sticky; top:0; z-index:40;
+}
+.brand{color:#fff; font-weight:900; text-decoration:none; white-space:nowrap}
+.nav-links{display:flex; gap:14px; flex-wrap:wrap}
+.nav-links a{color:#cfd6ec; text-decoration:none; font-size:14px; opacity:.9}
+.nav-links a:hover{opacity:1}
+.nav-actions{display:flex; gap:10px}
+.btn{
+  appearance:none; border:0; border-radius:12px; padding:12px 16px; font-weight:800;
+  background:var(--accent); color:#fff; cursor:pointer; text-decoration:none;
+  transition:.2s background,.05s transform;
+}
+.btn:hover{background:var(--accent-2)} .btn:active{transform:translateY(1px)}
+.btn.ghost{background:rgba(255,255,255,.04); border:1px solid var(--line); color:var(--ink)}
+
+/* ==== HERO ==== */
+:root{ --heroSize: 480px; }
+.hero-grid{
+  max-width:1080px; margin:0 auto; padding:56px 18px;
+  display:grid; grid-template-columns: 1.1fr var(--heroSize);
+  gap:40px; align-items:center;
+}
+.hero h1{ font-size:56px; line-height:1.1; font-weight:900; margin:0 0 16px; }
+.hero h1 .grad{
+  background: linear-gradient(90deg,#c4b5fd,#7c3aed);
+  -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent; color:transparent;
+}
+.hero .sub{ color:#cfd6ec; margin:0 0 18px; }
+.cta{ display:flex; gap:10px; flex-wrap:wrap; }
+.tiny{ font-size:12px; color:#9aa3b2; margin-top:6px; }
+
+.hero .hero-media{
+  width: var(--heroSize); height: var(--heroSize); aspect-ratio: 1 / 1;
+  position: relative; overflow: hidden; margin-left:auto; border-radius:16px;
+  border:1px solid var(--line);
+  background:linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
+  box-shadow:0 20px 60px rgba(0,0,0,.35);
+}
+.hero .hero-img{
+  position:absolute; inset:0; width:100%; height:100%;
+  object-fit:cover; object-position: 50% 12%;
+}
+
+/* ==== TITULARES DE SECCIÓN ==== */
+section h2{font-size:32px;margin:0 0 8px;text-align:center}
+.section-sub{ text-align:center; color:var(--muted); margin:0 0 24px; }
+
+/* ==== CARDS BASE (glass) ==== */
+.cards{ display:grid; gap:16px; }
+.grid-3{ grid-template-columns:repeat(3,1fr); }
+.grid-2{ grid-template-columns:repeat(2,1fr); }
+
+.card{
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  border:1px solid var(--line);
+  border-radius:16px; padding:18px;
+  backdrop-filter: blur(8px);
+  box-shadow:0 16px 48px rgba(0,0,0,.28);
+}
+.card h3{margin:6px 0 8px}
+.card p{margin:0; color:#d8def5}
+.card-emoji{font-size:24px}
+
+/* ==== MODOS ==== */
+.mode-title{font-weight:900;display:flex;align-items:center;gap:8px;margin-bottom:6px}
+.mode .dot{width:10px;height:10px;border-radius:50%;display:inline-block}
+.mode.low{border-left:3px solid var(--low)}
+.mode.low .dot{background:var(--low)}
+.mode.chill{border-left:3px solid var(--chill)}
+.mode.chill .dot{background:var(--chill)}
+.mode.flow{border-left:3px solid var(--flow)}
+.mode.flow .dot{background:var(--flow)}
+.mode.evolve{border-left:3px solid var(--evolve)}
+.mode.evolve .dot{background:var(--evolve)}
+.muted{color:#b7bfd4}
+
+/* ==== CÓMO FUNCIONA (timeline) ==== */
+.steps{ list-style:none; padding:0; margin:0; display:grid; gap:14px; }
+.steps li{
+  display:grid; grid-template-columns:auto 1fr; gap:12px; align-items:start;
+  background:linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
+  border:1px solid var(--line); border-radius:14px; padding:14px;
+}
+.step-badge{
+  width:32px; height:32px; border-radius:10px;
+  display:inline-grid; place-items:center; font-weight:800;
+  color:#fff; background: radial-gradient(80% 80% at 30% 20%, #a78bfa, #7c3aed);
+  box-shadow:0 6px 20px rgba(124,58,237,.35);
+}
+
+/* ==== TRUST BAR ==== */
+.logo-row{
+  display:grid; grid-template-columns:repeat(5,1fr); gap:12px; margin-top:14px;
+}
+.logo-ph{
+  height:56px; border:1px dashed var(--line); border-radius:12px;
+  display:grid; place-items:center; color:#9aa3b2; background:rgba(255,255,255,.03);
+}
+
+/* ==== TESTIMONIOS scrollable ==== */
+.testi-scroller{
+  display:grid; grid-auto-flow:column; grid-auto-columns: min(100%, 520px);
+  overflow-x:auto; gap:16px; padding-bottom:6px; scroll-snap-type:x mandatory;
+}
+.testi{ scroll-snap-align:start; margin:0; padding:18px; border:1px solid var(--line); border-radius:16px;
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02)); backdrop-filter: blur(8px);
+}
+.testi blockquote{ margin:0 0 10px; color:#e8ecf1; font-weight:600; }
+.testi figcaption{ color:#9aa3b2; }
+
+/* ==== FAQ ==== */
+.faq details{
+  background:linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
+  border:1px solid var(--line); border-radius:12px; padding:14px 16px; margin:10px 0;
+}
+.faq summary{ cursor:pointer; font-weight:700; color:#e8ecf1; }
+.faq p{ margin:8px 0 0; color:#cfd6ec }
+
+/* ==== CTA FINAL ==== */
+.next .cta.center{justify-content:center; display:flex; gap:10px;}
+
+/* ==== FOOTER ==== */
+.footer{
+  border-top:1px solid var(--line); padding:18px;
+  display:flex; align-items:center; justify-content:space-between; color:#cfd6ec
+}
+.footer a{color:#cfd6ec; text-decoration:none}
+.footer a:hover{text-decoration:underline}
+
+/* ==== RESPONSIVE ==== */
+@media (max-width:1100px){
+  :root{ --heroSize: min(92vw, 540px); }
+  .hero-grid{ grid-template-columns:1fr; gap:24px; padding-top:36px; }
+  .hero .hero-media{ margin-left:0; }
+}
+@media (max-width:900px){
+  .nav-links{ display:none; } /* simplifica nav en móvil */
+  .grid-3{ grid-template-columns:1fr; }
+  .grid-2{ grid-template-columns:1fr; }
+  .logo-row{ grid-template-columns:repeat(3,1fr); }
+  .hero h1{ font-size:38px; }
+}
+@media (max-width:480px){
+  .logo-row{ grid-template-columns:repeat(2,1fr); }
+  .hero h1{ font-size:32px; }
+}
+
+/* ==== SLIDER (Testimonios) ==== */
+.slider{ position:relative; overflow:hidden; border-radius:16px; }
+.slider-track{ display:flex; transition:transform .5s ease; }
+.slider .testi{ min-width:100%; box-sizing:border-box; margin:0; padding:22px; 
+  border:1px solid var(--line); border-radius:16px;
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  backdrop-filter: blur(8px);
+}
+.slider .testi blockquote{ margin:0 0 10px; color:#e8ecf1; font-weight:600; }
+.slider .testi figcaption{ color:#9aa3b2; }
+
+.slider-btn{
+  position:absolute; top:50%; transform:translateY(-50%);
+  background:rgba(255,255,255,.06); border:1px solid var(--line);
+  color:#fff; width:40px; height:40px; border-radius:10px; cursor:pointer;
+  display:grid; place-items:center;
+}
+.slider-btn:hover{ background:rgba(255,255,255,.1); }
+.slider-btn.prev{ left:8px; }
+.slider-btn.next{ right:8px; }
+
+.slider-dots{ display:flex; gap:8px; justify-content:center; margin-top:12px; }
+.dot{
+  width:10px; height:10px; border-radius:50%;
+  background:rgba(255,255,255,.25); border:0; cursor:pointer;
+}
+.dot[aria-selected="true"]{ background:#fff; }
+
+.visually-hidden{
+  position:absolute; width:1px; height:1px; margin:-1px; padding:0; overflow:hidden; clip:rect(0 0 0 0); border:0;
+}

--- a/refactor/js/features/landing.js
+++ b/refactor/js/features/landing.js
@@ -1,0 +1,104 @@
+/**
+ * Módulo: Landing
+ * Propósito: animar el carrusel de testimonios sin cambiar su experiencia.
+ * API pública: init(rootEl)
+ * Dependencias: utils/dom, utils/a11y.
+ * Side-effects: timers de autoplay y listeners sobre el carrusel.
+ * Errores esperados: si falta el carrusel, solo se reporta en consola.
+ * Notas de accesibilidad: actualiza aria-selected y responde a teclas.
+ */
+
+import { byId, qsa, on } from '../utils/dom.js';
+import { announce } from '../utils/a11y.js';
+
+const AUTOPLAY_INTERVAL_MS = 4000;
+
+// ===== [Feature: Landing Carousel] =====
+// Esta parte mueve los testimonios como un trencito de tarjetas.
+function createCarousel(root) {
+  if (!root) {
+    console.error('[Landing] No encontré el carrusel de testimonios');
+    return { teardown() {} };
+  }
+
+  const track = root.querySelector('.slider-track');
+  const slides = qsa(':scope .slider-track > *', root);
+  const prevBtn = root.querySelector('.slider-btn.prev');
+  const nextBtn = root.querySelector('.slider-btn.next');
+  const dots = qsa('.dot', root);
+
+  if (!track || slides.length === 0) {
+    console.error('[Landing] El carrusel no tiene tarjetas para mostrar');
+    return { teardown() {} };
+  }
+
+  let index = 0;
+  let timer = null;
+
+  const goTo = (newIndex) => {
+    index = (newIndex + slides.length) % slides.length;
+    track.style.transform = `translateX(-${index * 100}%)`;
+    dots.forEach((dot, dotIndex) => {
+      dot.setAttribute('aria-selected', dotIndex === index ? 'true' : 'false');
+    });
+    announce(`Testimonio ${index + 1} de ${slides.length}`);
+  };
+
+  const play = () => {
+    stop();
+    timer = window.setInterval(() => goTo(index + 1), AUTOPLAY_INTERVAL_MS);
+  };
+
+  const stop = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  const destroyers = [];
+
+  destroyers.push(on(prevBtn, 'click', () => goTo(index - 1)));
+  destroyers.push(on(nextBtn, 'click', () => goTo(index + 1)));
+  dots.forEach((dot, dotIndex) => {
+    destroyers.push(on(dot, 'click', () => goTo(dotIndex)));
+  });
+
+  destroyers.push(on(root, 'mouseenter', stop));
+  destroyers.push(on(root, 'mouseleave', play));
+  destroyers.push(on(root, 'keydown', (event) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      goTo(index - 1);
+    }
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      goTo(index + 1);
+    }
+  }));
+
+  goTo(0);
+  play();
+
+  return {
+    teardown() {
+      stop();
+      destroyers.forEach((fn) => fn && fn());
+    },
+  };
+}
+
+export function init(root = document) {
+  const slider = createCarousel(byId('testi-slider'));
+  return {
+    teardown() {
+      slider.teardown();
+    },
+  };
+}
+
+// ===== [Auto arranque] =====
+// Esperamos a que el DOM esté listo para encender el carrusel.
+document.addEventListener('DOMContentLoaded', () => {
+  init(document);
+});

--- a/refactor/js/features/login.js
+++ b/refactor/js/features/login.js
@@ -1,0 +1,485 @@
+/**
+ * Módulo: Login
+ * Propósito: replicar el flujo original de login, modales y PWA.
+ * API pública: init()
+ * Dependencias: utils/dom, utils/net, utils/a11y, utils/constants.
+ * Side-effects: timers de polling, localStorage/sessionStorage, registro de SW.
+ * Errores esperados: caídas de red o endpoints sin configurar → se informan en consola.
+ * Notas de accesibilidad: controla focus dentro de modales y anuncia estados.
+ */
+
+import {
+  byId,
+  on,
+  setHTML,
+  toggleHidden,
+  focusFirstInteractive,
+} from '../utils/dom.js';
+import { announce, trapFocus, releaseFocus } from '../utils/a11y.js';
+import {
+  CHECK_ENDPOINT,
+  POLL_INTERVAL_MS,
+  DASHBOARD_ROUTE,
+  REFRESH_ENDPOINT,
+  STORAGE_KEYS,
+  BUNDLE_SOFT_DELAY_MS,
+  WORKER_BASE,
+  OLD_WEBAPP_URL,
+} from '../utils/constants.js';
+
+const state = {
+  pollTimer: null,
+  lastEmail: '',
+  deferredPrompt: null,
+};
+
+const SELECTORS = {
+  loginWrap: 'loginWrap',
+  loginForm: 'loginForm',
+  email: 'email',
+  goBtn: 'goBtn',
+  status: 'status',
+  awaitModal: 'awaitModal',
+  notFoundModal: 'notFoundModal',
+  closeAwait: 'closeModal',
+  closeNotFound: 'closeNF',
+  backNotFound: 'backNF',
+  signupNF: 'signupNF',
+  installBtn: 'installBtn',
+  copyLinkBtn: 'copyLinkBtn',
+  installHelp: 'installHelp',
+  retry: 'retryBtn',
+};
+
+const USER_AGENT = navigator.userAgent || '';
+const IS_IOS = /iPhone|iPad|iPod/i.test(USER_AGENT);
+const IS_STANDALONE = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true;
+
+// ===== [Helpers: Query params] =====
+function getQueryParam(name) {
+  const params = new URLSearchParams(window.location.search);
+  return (params.get(name) || '').trim();
+}
+
+// ===== [Helpers: Status] =====
+function setStatus(message, spinning = false) {
+  const statusEl = byId(SELECTORS.status);
+  if (!statusEl) return;
+  const spinner = spinning ? ' <span class="spinner" aria-hidden="true"></span>' : '';
+  setHTML(statusEl, `${message}${spinner}`);
+  if (message) {
+    announce(message);
+  }
+}
+
+// ===== [Helpers: Modales] =====
+function showModal(id) {
+  const modal = byId(id);
+  if (!modal) return;
+  modal.classList.add('visible');
+  modal.setAttribute('aria-hidden', 'false');
+  trapFocus(modal);
+  focusFirstInteractive(modal);
+}
+
+function hideModal(id) {
+  const modal = byId(id);
+  if (!modal) return;
+  modal.classList.remove('visible');
+  modal.setAttribute('aria-hidden', 'true');
+  releaseFocus();
+}
+
+function hideLogin() {
+  const wrap = byId(SELECTORS.loginWrap);
+  toggleHidden(wrap, true);
+}
+
+function showLogin() {
+  const wrap = byId(SELECTORS.loginWrap);
+  toggleHidden(wrap, false);
+  const email = byId(SELECTORS.email);
+  if (email) {
+    email.focus();
+  }
+}
+
+// ===== [Helpers: Cache bundle] =====
+function getCachedBundle() {
+  try {
+    const data = localStorage.getItem(STORAGE_KEYS.BUNDLE_CACHE);
+    return data ? JSON.parse(data) : null;
+  } catch (error) {
+    console.error('[Login] No pude leer el bundle cacheado', error);
+    return null;
+  }
+}
+
+function setCachedBundle(bundle) {
+  try {
+    localStorage.setItem(STORAGE_KEYS.BUNDLE_CACHE, JSON.stringify(bundle));
+  } catch (error) {
+    console.error('[Login] No pude guardar el bundle cacheado', error);
+  }
+}
+
+async function loadDataFromCacheOrWebApp(email) {
+  try {
+    const response = await fetch(`${WORKER_BASE}/bundle?email=${encodeURIComponent(email)}`, { cache: 'no-store' });
+    if (response.status === 200) {
+      return await response.json();
+    }
+    if (response.status === 204) {
+      throw new Error('No bundle yet');
+    }
+    throw new Error(`Worker ${response.status}`);
+  } catch (error) {
+    const fallback = await fetch(`${OLD_WEBAPP_URL}?email=${encodeURIComponent(email)}`, { cache: 'no-store' });
+    return fallback.json();
+  }
+}
+
+async function primeBundlePrefetch(email) {
+  try {
+    const data = await loadDataFromCacheOrWebApp(email);
+    if (data) {
+      setCachedBundle(data);
+    }
+  } catch (error) {
+    console.error('[Login] No pude prefetchear el bundle', error);
+  }
+}
+
+function pokeRefreshWorker(email) {
+  try {
+    const payload = JSON.stringify({ email });
+    if (navigator.sendBeacon) {
+      const blob = new Blob([payload], { type: 'application/json' });
+      navigator.sendBeacon(REFRESH_ENDPOINT, blob);
+    } else {
+      fetch(REFRESH_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        keepalive: true,
+        cache: 'no-store',
+      }).catch(() => {});
+    }
+  } catch (error) {
+    console.error('[Login] No pude notificar al worker de refresh', error);
+  }
+}
+
+function markPrimeFlags(delayMs = BUNDLE_SOFT_DELAY_MS) {
+  try {
+    sessionStorage.setItem(STORAGE_KEYS.PRIME_FLAG, '1');
+    sessionStorage.setItem(STORAGE_KEYS.PRIME_DELAY, String(delayMs));
+  } catch (error) {
+    console.error('[Login] No pude guardar los flags de refresh', error);
+  }
+}
+
+// ===== [Helpers: Chequeo de estado] =====
+async function checkStatus(email) {
+  const url = `${CHECK_ENDPOINT}?email=${encodeURIComponent(email)}`;
+  const response = await fetch(url, { cache: 'no-store' });
+  if (response.status === 404) {
+    return { ok: false, notFound: true };
+  }
+  let data = {};
+  try {
+    data = await response.json();
+  } catch (error) {
+    data = {};
+  }
+  if (data && data.notFound) {
+    return { ok: false, notFound: true };
+  }
+  return data;
+}
+
+function isReady(data) {
+  return Boolean(data && data.ok && (data.has_url || data.ready));
+}
+
+function isNotFound(data) {
+  if (!data) return false;
+  if (data.notFound === true) return true;
+  const message = (data.message || data.error || data.reason || '').toString().toLowerCase();
+  return /no existe|not found|no encontrado/.test(message);
+}
+
+function goToDashboard(email) {
+  window.location.href = `${DASHBOARD_ROUTE}?email=${encodeURIComponent(email)}`;
+}
+
+function startPolling() {
+  stopPolling();
+  state.pollTimer = window.setInterval(async () => {
+    if (!state.lastEmail) return;
+    try {
+      const data = await checkStatus(state.lastEmail);
+      if (isNotFound(data)) {
+        stopPolling();
+        hideModal(SELECTORS.awaitModal);
+        showLogin();
+        setStatus('Ese correo no está registrado.');
+        showModal(SELECTORS.notFoundModal);
+        return;
+      }
+      if (isReady(data)) {
+        stopPolling();
+        hideModal(SELECTORS.awaitModal);
+        goToDashboard(state.lastEmail);
+      }
+    } catch (error) {
+      console.error('[Login] Falló el polling', error);
+    }
+  }, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (state.pollTimer) {
+    clearInterval(state.pollTimer);
+    state.pollTimer = null;
+  }
+}
+
+// ===== [Acciones: envío del formulario] =====
+async function handleSubmit(event) {
+  event.preventDefault();
+  const emailInput = byId(SELECTORS.email);
+  const goBtn = byId(SELECTORS.goBtn);
+  const email = (emailInput?.value || '').trim().toLowerCase();
+
+  if (!email || !email.includes('@')) {
+    setStatus('Ingresá un correo válido.');
+    return;
+  }
+
+  state.lastEmail = email;
+
+  if (!CHECK_ENDPOINT || CHECK_ENDPOINT.startsWith('PON_AQUI')) {
+    hideLogin();
+    showModal(SELECTORS.awaitModal);
+    return;
+  }
+
+  if (goBtn) goBtn.disabled = true;
+  if (goBtn) goBtn.style.opacity = '0.7';
+  setStatus('Chequeando estado…', true);
+
+  try {
+    const data = await checkStatus(email);
+
+    if (isNotFound(data)) {
+      setStatus('Ese correo no está registrado.');
+      hideModal(SELECTORS.awaitModal);
+      showModal(SELECTORS.notFoundModal);
+      const signup = byId(SELECTORS.signupNF);
+      if (signup) {
+        signup.focus();
+      }
+      return;
+    }
+
+    if (isReady(data)) {
+      setStatus('Listo, entrando…', true);
+      try {
+        await primeBundlePrefetch(email);
+      } catch (_) {
+        // ya se logueó en consola
+      }
+      pokeRefreshWorker(email);
+      markPrimeFlags(BUNDLE_SOFT_DELAY_MS);
+      goToDashboard(email);
+      return;
+    }
+
+    setStatus('Tu base está en camino. Voy a esperar con vos…', true);
+    hideLogin();
+    showModal(SELECTORS.awaitModal);
+    startPolling();
+  } catch (error) {
+    console.error('[Login] Error revisando el estado', error);
+    setStatus('Ups, algo falló. Intentá de nuevo en unos segundos.');
+  } finally {
+    if (goBtn) {
+      goBtn.disabled = false;
+      goBtn.style.opacity = '1';
+    }
+  }
+}
+
+// ===== [Acciones: cerrar modales] =====
+function wireModalActions() {
+  const closeAwait = byId(SELECTORS.closeAwait);
+  on(closeAwait, 'click', () => {
+    stopPolling();
+    hideModal(SELECTORS.awaitModal);
+    showLogin();
+    setStatus('Listo para intentar de nuevo.');
+  });
+
+  const retry = byId(SELECTORS.retry);
+  if (retry) {
+    on(retry, 'click', async () => {
+      if (!state.lastEmail) return;
+      const original = retry.textContent;
+      setHTML(retry, 'Reintentando <span class="spinner" aria-hidden="true"></span>');
+      retry.disabled = true;
+      try {
+        const data = await checkStatus(state.lastEmail);
+        if (isNotFound(data)) {
+          stopPolling();
+          hideModal(SELECTORS.awaitModal);
+          showLogin();
+          setStatus('Ese correo no está registrado.');
+          showModal(SELECTORS.notFoundModal);
+          return;
+        }
+        if (isReady(data)) {
+          stopPolling();
+          hideModal(SELECTORS.awaitModal);
+          goToDashboard(state.lastEmail);
+        }
+      } catch (error) {
+        console.error('[Login] Error al reintentar', error);
+      } finally {
+        retry.textContent = original;
+        retry.disabled = false;
+      }
+    });
+  }
+
+  const closeNF = byId(SELECTORS.closeNotFound);
+  const backNF = byId(SELECTORS.backNotFound);
+
+  on(closeNF, 'click', () => hideModal(SELECTORS.notFoundModal));
+  on(backNF, 'click', () => hideModal(SELECTORS.notFoundModal));
+}
+
+// ===== [Acciones: teclado] =====
+function wireEnterShortcut() {
+  on(document, 'keydown', (event) => {
+    const email = byId(SELECTORS.email);
+    if (event.key === 'Enter' && document.activeElement === email) {
+      event.preventDefault();
+      byId(SELECTORS.goBtn)?.click();
+    }
+  });
+}
+
+// ===== [Acciones: PWA] =====
+function buildPortalUrlForMobile() {
+  const base = `${window.location.origin}${window.location.pathname}`;
+  const email = (byId(SELECTORS.email)?.value || '').trim().toLowerCase();
+  const params = new URLSearchParams({ await: '1' });
+  if (email) params.set('email', email);
+  return `${base}?${params.toString()}`;
+}
+
+function wirePwaActions() {
+  const installBtn = byId(SELECTORS.installBtn);
+  const copyLinkBtn = byId(SELECTORS.copyLinkBtn);
+  const installHelp = byId(SELECTORS.installHelp);
+
+  if (installBtn && IS_IOS) {
+    installBtn.style.display = 'inline-block';
+  }
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    if (IS_STANDALONE) return;
+    event.preventDefault();
+    state.deferredPrompt = event;
+    if (installBtn) installBtn.style.display = 'inline-block';
+  });
+
+  on(installBtn, 'click', async () => {
+    if (state.deferredPrompt) {
+      state.deferredPrompt.prompt();
+      try {
+        await state.deferredPrompt.userChoice;
+      } catch (error) {
+        console.error('[Login] Instalación rechazada o fallida', error);
+      }
+      state.deferredPrompt = null;
+      return;
+    }
+    if (IS_IOS) {
+      if (installHelp) installHelp.style.display = 'block';
+      return;
+    }
+    alert('Si tu navegador lo permite, usá “Instalar app / Agregar a la pantalla de inicio”.');
+  });
+
+  on(copyLinkBtn, 'click', async () => {
+    if (!copyLinkBtn) return;
+    const url = buildPortalUrlForMobile();
+    try {
+      await navigator.clipboard.writeText(url);
+      const original = copyLinkBtn.textContent || '';
+      copyLinkBtn.textContent = 'Copiado ✓';
+      setTimeout(() => {
+        copyLinkBtn.textContent = original;
+      }, 1400);
+    } catch (error) {
+      console.error('[Login] No pude copiar al portapapeles', error);
+      window.prompt('Copiá este link:', url);
+    }
+  });
+}
+
+function wireServiceWorker() {
+  if (!('serviceWorker' in navigator)) return;
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('../../sw.js', { scope: '../../' })  // TODO: usar sw.refactor.js en Lote 4
+      .then((registration) => console.log('[SW] registrado', registration.scope))
+      .catch((error) => console.error('[SW] error', error));
+  });
+}
+
+// ===== [Boot] =====
+export function init() {
+  const form = byId(SELECTORS.loginForm);
+  if (!form) {
+    console.error('[Login] No encontré el formulario de login');
+    return { teardown() {} };
+  }
+
+  form.addEventListener('submit', handleSubmit);
+  wireModalActions();
+  wireEnterShortcut();
+  wirePwaActions();
+  wireServiceWorker();
+
+  const preloadEmail = getQueryParam('email');
+  if (preloadEmail) {
+    const emailInput = byId(SELECTORS.email);
+    if (emailInput) emailInput.value = preloadEmail;
+    state.lastEmail = preloadEmail.toLowerCase();
+  }
+
+  const forceAwait = getQueryParam('await');
+  if (forceAwait === '1') {
+    hideLogin();
+    showModal(SELECTORS.awaitModal);
+    if (state.lastEmail) {
+      startPolling();
+    }
+  }
+
+  announce('Pantalla de login lista.');
+
+  return {
+    teardown() {
+      form.removeEventListener('submit', handleSubmit);
+      stopPolling();
+    },
+  };
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  init();
+});

--- a/refactor/js/utils/a11y.js
+++ b/refactor/js/utils/a11y.js
@@ -1,0 +1,97 @@
+/**
+ * Módulo: A11yUtils
+ * Propósito: agrupar helpers para foco y mensajes amigables.
+ * API pública: trapFocus(container), releaseFocus(), announce(message, politeness)
+ * Dependencias: utils/dom.
+ * Side-effects: maneja focus en document.activeElement y aria-live global.
+ * Errores esperados: contenedores inexistentes → se ignoran avisando por consola.
+ * Notas de accesibilidad: refuerza que los modales sean navegables.
+ */
+
+import { qsa } from './dom.js';
+
+let lastFocused = null;
+let currentTrap = null;
+let announcer = null;
+
+/**
+ * ===== [A11y: crear announcer] =====
+ * Genera un div aria-live para comunicar mensajes cortos.
+ */
+function ensureAnnouncer() {
+  if (announcer) return announcer;
+  announcer = document.createElement('div');
+  announcer.setAttribute('role', 'status');
+  announcer.setAttribute('aria-live', 'polite');
+  announcer.setAttribute('aria-atomic', 'true');
+  announcer.style.position = 'absolute';
+  announcer.style.width = '1px';
+  announcer.style.height = '1px';
+  announcer.style.margin = '-1px';
+  announcer.style.border = '0';
+  announcer.style.padding = '0';
+  announcer.style.clip = 'rect(0 0 0 0)';
+  document.body.appendChild(announcer);
+  return announcer;
+}
+
+/**
+ * ===== [A11y: anunciar mensajes] =====
+ * Envía texto al aria-live para lectores de pantalla.
+ */
+export function announce(message, politeness = 'polite') {
+  const node = ensureAnnouncer();
+  node.setAttribute('aria-live', politeness);
+  node.textContent = message;
+}
+
+/**
+ * ===== [A11y: atrapar foco en un modal] =====
+ * Guarda quién tenía el foco, y cicla dentro del contenedor.
+ */
+export function trapFocus(container) {
+  if (!container) {
+    console.error('[A11yUtils] No encontré el contenedor para trapFocus');
+    return;
+  }
+  lastFocused = document.activeElement;
+  currentTrap = container;
+  const focusables = qsa('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])', container);
+  if (focusables.length > 0) {
+    focusables[0].focus();
+  }
+
+  const handleKeydown = (event) => {
+    if (event.key !== 'Tab' || !currentTrap) return;
+    const elements = qsa('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])', currentTrap);
+    if (elements.length === 0) return;
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  container.__trapHandler = handleKeydown;
+  document.addEventListener('keydown', handleKeydown);
+}
+
+/**
+ * ===== [A11y: liberar foco] =====
+ * Regresa el foco al elemento previo si todavía existe.
+ */
+export function releaseFocus() {
+  if (currentTrap && currentTrap.__trapHandler) {
+    document.removeEventListener('keydown', currentTrap.__trapHandler);
+    delete currentTrap.__trapHandler;
+  }
+  currentTrap = null;
+  if (lastFocused && typeof lastFocused.focus === 'function') {
+    lastFocused.focus();
+  }
+  lastFocused = null;
+}

--- a/refactor/js/utils/constants.js
+++ b/refactor/js/utils/constants.js
@@ -1,0 +1,27 @@
+/**
+ * Módulo: AppConstants
+ * Propósito: centralizar endpoints, rutas y claves de storage.
+ * API pública: export const con strings mágicos y números usados en features.
+ * Dependencias: ninguna.
+ * Side-effects: ninguno.
+ * Errores esperados: si se cambia un endpoint, actualizar aquí.
+ * Notas de accesibilidad: sin impacto directo, pero evita duplicar valores.
+ */
+
+export const CHECK_ENDPOINT = 'https://script.google.com/macros/s/AKfycbzOvVEFFtNQfFE28AK5Tgi7kwdzn4if5tbLHofmlyAQ3fiVLdQgwXah2TcqTZDLEzua/exec';
+export const POLL_INTERVAL_MS = 10000;
+export const DASHBOARD_ROUTE = 'dashboardv3.html';
+
+export const WORKER_BASE = 'https://gamificationworker.rfullivarri22.workers.dev';
+export const OLD_WEBAPP_URL = 'https://script.google.com/macros/s/AKfycbxncfav0V6OJsHDFMcFg7S8qISWXrG5P5l5WTCzBn-iC_4cerC22lsznJHlDsQhneGdpA/exec';
+
+export const BUNDLE_ENDPOINT = `${WORKER_BASE}/bundle`;
+export const REFRESH_ENDPOINT = `${WORKER_BASE}/refresh`;
+
+export const STORAGE_KEYS = {
+  BUNDLE_CACHE: 'gj_bundle',
+  PRIME_FLAG: 'gj_prime',
+  PRIME_DELAY: 'gj_soft_delay_ms',
+};
+
+export const BUNDLE_SOFT_DELAY_MS = 12000;

--- a/refactor/js/utils/dom.js
+++ b/refactor/js/utils/dom.js
@@ -1,0 +1,108 @@
+/**
+ * Módulo: DOMUtils
+ * Propósito: reunir helpers pequeñitos para consultar nodos y manejar eventos.
+ * API pública: byId(id), qs(selector, scope), qsa(selector, scope), on(el, evt, handler), delegate(root, evt, selector, handler), setHTML(el, html), toggleHidden(el, force)
+ * Dependencias: ninguna (módulo base).
+ * Side-effects: ninguno, solo lee/modifica nodos recibidos.
+ * Errores esperados: recibe nodos nulos y sale con mensajes amigables.
+ * Notas de accesibilidad: permite manejar focos y atributos sin duplicar código.
+ */
+
+/**
+ * ===== [DOMUtils: seleccionar por ID] =====
+ * Devuelve el elemento si existe; si no, avisa en consola y retorna null.
+ */
+export function byId(id) {
+  const el = document.getElementById(id);
+  if (!el) {
+    console.error(`[DOMUtils] No encontré el elemento con id="${id}"`);
+  }
+  return el;
+}
+
+/**
+ * ===== [DOMUtils: querySelector seguro] =====
+ * Busca dentro de scope (o document) y devuelve el primer match.
+ */
+export function qs(selector, scope = document) {
+  if (!scope) {
+    console.error('[DOMUtils] No tengo un scope para buscar', selector);
+    return null;
+  }
+  return scope.querySelector(selector);
+}
+
+/**
+ * ===== [DOMUtils: querySelectorAll sencillo] =====
+ * Siempre devuelve un array para que podamos usar forEach sin miedo.
+ */
+export function qsa(selector, scope = document) {
+  if (!scope) {
+    console.error('[DOMUtils] No tengo un scope para buscar muchos', selector);
+    return [];
+  }
+  return Array.from(scope.querySelectorAll(selector));
+}
+
+/**
+ * ===== [DOMUtils: escuchar eventos] =====
+ * Adjunta un listener y devuelve una función para removerlo.
+ */
+export function on(target, eventName, handler, options) {
+  if (!target) {
+    console.error(`[DOMUtils] Intenté escuchar ${eventName} pero no encontré el nodo`);
+    return () => {};
+  }
+  target.addEventListener(eventName, handler, options);
+  return () => target.removeEventListener(eventName, handler, options);
+}
+
+/**
+ * ===== [DOMUtils: delegar eventos] =====
+ * Escucha un evento en root y lo ejecuta cuando el target coincide con selector.
+ */
+export function delegate(root, eventName, selector, handler) {
+  return on(root, eventName, (event) => {
+    const potential = event.target.closest(selector);
+    if (potential && root.contains(potential)) {
+      handler(event, potential);
+    }
+  });
+}
+
+/**
+ * ===== [DOMUtils: setear HTML] =====
+ * Reemplaza el contenido de un nodo; si el nodo no existe, lo ignora sin romper.
+ */
+export function setHTML(element, html) {
+  if (!element) {
+    console.error('[DOMUtils] No pude escribir HTML porque el elemento es nulo');
+    return;
+  }
+  element.innerHTML = html;
+}
+
+/**
+ * ===== [DOMUtils: mostrar/ocultar con hidden] =====
+ * Usa el atributo hidden para no tocar clases ni estilos externos.
+ */
+export function toggleHidden(element, force) {
+  if (!element) {
+    console.error('[DOMUtils] No pude alternar hidden porque el elemento es nulo');
+    return;
+  }
+  const shouldHide = typeof force === 'boolean' ? force : !element.hidden;
+  element.hidden = shouldHide;
+  element.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
+}
+
+/**
+ * ===== [DOMUtils: enfocar el primer elemento navegable] =====
+ * Busca botones, enlaces o inputs y les da foco.
+ */
+export function focusFirstInteractive(scope) {
+  const focusables = qsa('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])', scope);
+  if (focusables.length > 0) {
+    focusables[0].focus();
+  }
+}

--- a/refactor/js/utils/net.js
+++ b/refactor/js/utils/net.js
@@ -1,0 +1,68 @@
+/**
+ * Módulo: NetUtils
+ * Propósito: envolver fetch con defaults seguros y fáciles de leer.
+ * API pública: fetchJson(url, options), postJson(url, body, options), withTimeout(promise, ms)
+ * Dependencias: ninguna.
+ * Side-effects: solo llamadas a fetch.
+ * Errores esperados: timeouts o respuestas no JSON → se reportan en consola.
+ * Notas de accesibilidad: sin impacto directo, pero mantiene mensajes claros.
+ */
+
+const DEFAULT_TIMEOUT_MS = 15000;
+
+/**
+ * ===== [NetUtils: timeout amigable] =====
+ * Si algo tarda mucho, lo cancelamos para no colgar la UI.
+ */
+export function withTimeout(promise, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`[NetUtils] La petición tardó más de ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+/**
+ * ===== [NetUtils: GET que devuelve JSON] =====
+ * Usa fetch y convierte la respuesta en objeto.
+ */
+export async function fetchJson(url, options = {}) {
+  try {
+    const response = await withTimeout(fetch(url, options), options.timeoutMs);
+    if (!response.ok && response.status !== 404) {
+      console.error('[NetUtils] Respuesta inesperada', response.status, url);
+    }
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  } catch (error) {
+    console.error('[NetUtils] No pude obtener JSON', url, error);
+    throw error;
+  }
+}
+
+/**
+ * ===== [NetUtils: POST JSON] =====
+ * Serializa el body y devuelve la respuesta parseada.
+ */
+export async function postJson(url, body, options = {}) {
+  const payload = typeof body === 'string' ? body : JSON.stringify(body);
+  const opts = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    body: payload,
+    keepalive: true,
+    cache: 'no-store',
+    ...options,
+  };
+  return fetchJson(url, opts);
+}

--- a/refactor/views/indexv2.refactor.html
+++ b/refactor/views/indexv2.refactor.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Innerbloom — Gamification Journey</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;600;800&display=swap" rel="stylesheet">
+  
+  <link rel="stylesheet" href="../css/base.css" />
+  <link rel="stylesheet" href="../css/stylesv3.css" />
+  <meta name="theme-color" content="#0b0f19" />
+</head>
+<body class="landing-body">
+  <!-- NAV -->
+  <header class="nav">
+    <a class="brand" href="indexv2.html" aria-label="Innerbloom — inicio">
+      <span class="brand-text">Innerbloom</span>
+      <img src="https://i.ibb.co/RpyF590p/innerbloom-white.png" alt="" class="logo-mark" width="32" height="32">
+    </a>
+  
+    <nav class="nav-links">
+      <a href="#overview">Overview</a>
+      <a href="#why">Nuestros Pilares</a>
+      <a href="#modes">Modos</a>
+      <a href="#how">Cómo funciona</a>
+      <a href="#features">Features</a>
+      <a href="#testimonials">Testimonios</a>
+      <a href="#faq">FAQ</a>
+    </nav>
+  
+    <nav class="nav-actions">
+      <a class="btn ghost" href="signupv2.html">Crear cuenta</a>
+      <a class="btn" href="loginv2.html">Ya tengo cuenta</a>
+    </nav>
+  </header>
+
+  
+  <!-- <header class="nav">
+    <a class="brand" href="indexv3.html">Innerbloom</a>
+
+    <nav class="nav-links">
+      <a href="#overview">Overview</a>
+      <a href="#why">¿Por qué 3 pilares?</a>
+      <a href="#pillars">Pilares</a>
+      <a href="#modes">Modos</a>
+      <a href="#how">Cómo funciona</a>
+      <a href="#features">Features</a>
+      <a href="#testimonials">Testimonios</a>
+      <a href="#faq">FAQ</a>
+    </nav>
+
+    <nav class="nav-actions">
+      <a class="btn ghost" href="signupv2.html">Crear cuenta</a>
+      <a class="btn" href="loginv2.html">Ya tengo cuenta</a>
+    </nav>
+  </header> -->
+  
+
+  <!-- HERO -->
+  <section class="hero" id="overview">
+    <div class="hero-grid">
+      <div class="hero-copy">
+        <h1>Convierte la experiencia en hábitos. <span class="grad">Convierte los hábitos en camino</span></h1>
+        <p class="sub">
+          Tus hábitos son el mapa. Tu constancia, el nivel que alcanzas. Es tu <strong>self-improvement journey</strong> con equilibro
+          entre <strong>🫀 Cuerpo</strong>, <strong>🧠 Mente</strong> y <strong>🏵️ Alma</strong>.
+        </p>
+        <div class="cta">
+          <a class="btn" href="formsintrov3.html">Comenzar mi Journey</a>
+          <a class="btn ghost" href="loginv2.html">Ya tengo cuenta</a>
+        </div>
+        <p class="tiny">En menos de 3 minutos generamos tu base personalizada con IA.</p>
+      </div>
+      <div class="hero-media">
+        <img
+          src="https://i.ibb.co/Gv7WTT7h/Whats-App-Image-2025-08-31-at-03-52-15.jpg"
+          alt="Niño mirando una esfera de energía violeta en el cielo nocturno — Gamification Journey"
+          class="hero-img" width="1200" height="1200" loading="eager" fetchpriority="high"
+        />
+      </div>
+    </div>
+  </section>
+
+  <!-- POR QUÉ LOS TRES PILARES -->
+  <section class="why section-pad" id="why">
+    <div class="container narrow">
+      <h2>Nuestros pilares fundamentales</h2>
+      <p class="section-sub">
+        El progreso sostenible necesita equilibrio. <strong>🫀 Cuerpo</strong> para la energía y la salud,
+        <strong>🧠 Mente</strong> para el foco y el aprendizaje, y <strong>🏵️ Alma</strong> para el bienestar emocional y el sentido.
+        Cuando uno cae, los otros dos lo sostienen. Cuando se alinean, tu progreso se acelera.
+      </p>
+
+      <div class="cards grid-3">
+        <article class="card">
+          <h3>🫀 Cuerpo</h3>
+          <p>Tu cuerpo es el sustrato del hábito: sueño, nutrición y movimiento marcan tu disponibilidad de energía diaria (HP).</p>
+        </article>
+        <article class="card">
+          <h3>🧠 Mente</h3>
+          <p>La mente filtra y prioriza. Sin foco, no hay consistencia. Diseñamos sesiones simples para sostener la atención el aprendizaje y la creatividad.</p>
+        </article>
+        <article class="card">
+          <h3>🏵️ Alma</h3>
+          <p>Las emociones, los vínculos y el propósito estabilizan el sistema. Sin esto, los hábitos no atraviesan semanas ni meses.</p>
+        </article>
+      </div>
+      </p>Observate por primera vez en tercera personas y toma el control de tus acciones y habitos.</p>
+    </div>
+  </section>
+
+  <!-- PILARES -->
+<!--   <section class="pillars section-pad" id="pillars">
+    <div class="container">
+      <h2>Los pilares</h2>
+      <p class="section-sub">Diseñados para que construyas constancia sin quemarte.</p>
+
+      <div class="cards grid-3">
+        <article class="card">
+          <div class="card-emoji">🫀</div>
+          <h3>Cuerpo</h3>
+          <p>Hábitos físicos que sostienen tu energía: sueño, movimiento, nutrición y cuidado cotidiano.</p>
+        </article>
+        <article class="card">
+          <div class="card-emoji">🧠</div>
+          <h3>Mente</h3>
+          <p>Foco, aprendizaje y claridad. Sesiones de atención para empujar objetivos de forma consistente.</p>
+        </article>
+        <article class="card">
+          <div class="card-emoji">🏵️</div>
+          <h3>Alma</h3>
+          <p>Bienestar emocional y sentido. Micro-prácticas para volver a estar bien y sostenerte en el tiempo.</p>
+        </article>
+      </div>
+    </div>
+  </section> -->
+
+  <!-- MODOS DE JUEGO -->
+  <section class="modes section-pad" id="modes">
+    <div class="container">
+      <h2>Mood tu modo de juego</h2>
+      <p class="section-sub">Cambia según tu momento. El sistema se adapta a tu energía.</p>
+
+      <div class="cards grid-2">
+        <article class="card mode low">
+          <div class="mode-title">🪫 LOW MOOD <span class="dot" aria-hidden="true"></span></div>
+          <p class="muted"><strong>Estado:</strong> sin energía, abrumado.</p>
+          <p><strong>Objetivo:</strong> activar tu mínimo vital con acciones pequeñas y sostenibles.</p>
+        </article>
+
+        <article class="card mode chill">
+          <div class="mode-title">🍃 CHILL MOOD <span class="dot" aria-hidden="true"></span></div>
+          <p class="muted"><strong>Estado:</strong> relajado y estable.</p>
+          <p><strong>Objetivo:</strong> sostener bienestar con rutinas suaves y balanceadas.</p>
+        </article>
+
+        <article class="card mode flow">
+          <div class="mode-title">🌊 FLOW MOOD <span class="dot" aria-hidden="true"></span></div>
+          <p class="muted"><strong>Estado:</strong> enfocado y en movimiento.</p>
+          <p><strong>Objetivo:</strong> aprovechar el impulso con un plan alineado a metas concretas.</p>
+        </article>
+
+        <article class="card mode evolve">
+          <div class="mode-title">🧬 EVOLVE MOOD <span class="dot" aria-hidden="true"></span></div>
+          <p class="muted"><strong>Estado:</strong> ambicioso y determinado.</p>
+          <p><strong>Objetivo:</strong> sistema retador con <em>Hábitos Atómicos</em>, misiones y recompensas.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- CÓMO FUNCIONA -->
+  <section class="how section-pad" id="how">
+    <div class="container narrow">
+      <h2>Cómo funciona</h2>
+      <p class="section-sub">Un flujo claro, de la activación a la constancia.</p>
+
+      <ol class="steps">
+        <li>
+          <span class="step-badge">1</span>
+          <div>
+            <h3>Define tu camino</h3>
+            <p>Responde una serie de preguntas, setea tu modo de juego, nostros generaremos tu base (Body/Mind/Soul) con IA.</p>
+          </div>
+        </li>
+        <li>
+          <span class="step-badge">2</span>
+          <div>
+            <h3>Activa tu base</h3>
+            <p>Recibís tu “pergamino digital” por mail y editás/confirmás tu base.</p>
+          </div>
+        </li>
+        <li>
+          <span class="step-badge">3</span>
+          <div>
+            <h3>Daily Quest + Emociones</h3>
+            <p>Con tu quest diaria vas a poder hacer una retrospectiva de tu día anterior; pensarás en qué emoción prevaleció más durante tu día.</p>
+          </div>
+        </li>
+        <li>
+          <span class="step-badge">4</span>
+          <div>
+            <h3>XP, Rachas y Recompensas</h3>
+            <p>Seguirás tu crecimiento acumulando experiencia (XP), moviendo tu constancia semanal, desafiándote a nuevas misiones y obteniendo recompensas.</p>
+          </div>
+        </li>
+      </ol>
+    </div>
+  </section>
+
+  <!-- FEATURES -->
+  <section class="features section-pad" id="features">
+    <div class="container">
+      <h2>Lo que desbloqueás</h2>
+      <p class="section-sub">Herramientas que te dan claridad y momentum.</p>
+  
+      <div class="cards grid-3">
+        <article class="card">
+          <h3>📝 Daily Quest</h3>
+          <p>Seguimiento de tareas por pilar y emoción diaria. 100% conectado a tu board.</p>
+        </article>
+        <article class="card">
+          <h3>⭐ XP & Nivel</h3>
+          <p>Progreso con datos reales. Barra de nivel y XP faltante al siguiente nivel.</p>
+        </article>
+        <article class="card">
+          <h3>📆 Constancia semanal</h3>
+          <p>Rachas por tarea: cuántas semanas seguidas mantienes la contacia de tus actividades.</p>
+        </article>
+        <article class="card">
+          <h3>🎯 Misiones & Rewards</h3>
+          <p>Misiones vinculadas a rachas. Bonos de XP al cumplir objetivos.</p>
+        </article>
+        <article class="card">
+          <h3>🗺️ Emotion Heatmap</h3>
+          <p>Mapa visual de tu estado emocional a lo largo del tiempo.</p>
+        </article>
+        <article class="card">
+          <h3>📱 App & Recordatorios</h3>
+          <p>Descarga nuestra APP y recibe recodatorios y mejor seguimiento</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <!-- TRUST BAR / LOGOS -->
+<!--   <section class="trust section-pad">
+    <div class="container narrow">
+      <h2>Quiénes ya nos eligen</h2>
+      <p class="section-sub">Profesionales, estudiantes y equipos que quieren ordenar su crecimiento personal.</p>
+      <div class="logo-row">
+        <div class="logo-ph">LOGO</div>
+        <div class="logo-ph">LOGO</div>
+        <div class="logo-ph">LOGO</div>
+        <div class="logo-ph">LOGO</div>
+        <div class="logo-ph">LOGO</div>
+      </div>
+    </div>
+  </section> -->
+
+  <!-- TESTIMONIOS -->
+  <section class="testimonials section-pad" id="testimonials">
+    <div class="container">
+      <h2>Testimonios</h2>
+      <p class="section-sub">Lo que dicen quienes ya empezaron su Journey.</p>
+  
+      <!-- Hook JS: #testi-slider lo mueve js/features/landing.js -->
+      <div class="slider" id="testi-slider" aria-roledescription="carousel">
+        <div class="slider-track">
+          <figure class="testi" role="group" aria-label="1 de 3">
+            <blockquote>“Por primera vez sostuve hábitos 6 semanas. El mapa y las misiones me ordenaron.”</blockquote>
+            <figcaption>Lucía • Diseñadora</figcaption>
+          </figure>
+          <figure class="testi" role="group" aria-label="2 de 3">
+            <blockquote>“El heatmap emocional me cambió la mirada. Ajusto tareas por energía real.”</blockquote>
+            <figcaption>Diego • Dev</figcaption>
+          </figure>
+          <figure class="testi" role="group" aria-label="3 de 3">
+            <blockquote>“Empecé en Low y pasé a Flow con objetivos claros, sin culpa.”</blockquote>
+            <figcaption>Caro • Estudiante</figcaption>
+          </figure>
+        </div>
+  
+        <button class="slider-btn prev" aria-label="Anterior">‹</button>
+        <button class="slider-btn next" aria-label="Siguiente">›</button>
+  
+        <div class="slider-dots" role="tablist" aria-label="Seleccionar testimonio">
+          <button class="dot" role="tab" aria-selected="true" aria-controls="slide-1"><span class="visually-hidden">1</span></button>
+          <button class="dot" role="tab" aria-selected="false" aria-controls="slide-2"><span class="visualmente-hidden">2</span></button>
+          <button class="dot" role="tab" aria-selected="false" aria-controls="slide-3"><span class="visually-hidden">3</span></button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="faq section-pad" id="faq">
+    <div class="container narrow">
+      <h2>Preguntas frecuentes</h2>
+      <details>
+        <summary>¿Necesito mucha disciplina para empezar?</summary>
+        <p>No. Si estás con poca energía, empezás en Low para activar el mínimo vital. El sistema ajusta el ritmo.</p>
+      </details>
+      <details>
+        <summary>¿Puedo cambiar de modo de juego?</summary>
+        <p>Sí. Podés cambiar entre Low, Chill, Flow y Evolve según tu momento.</p>
+      </details>
+      <details>
+        <summary>¿Dónde veo mis métricas?</summary>
+        <p>En tu archivo y en el Dashboard: XP, nivel, rachas y mapa emocional.</p>
+      </details>
+      <details>
+        <summary>¿Qué pasa si dejo de registrar?</summary>
+        <p>No perdés progreso. Retomás cuando quieras y ajustamos objetivos según tu energía.</p>
+      </details>
+    </div>
+  </section>
+
+  <!-- CTA FINAL -->
+  <section class="next section-pad">
+    <div class="container narrow center">
+      <h2>Listo para empezar</h2>
+      <p class="section-sub">Te guiamos paso a paso. Empieza ahora.</p>
+      <div class="cta center">
+        <a class="btn" href="formsintrov3.html">Comenzar mi Journey</a>
+        <a class="btn ghost" href="loginv2.html">Ya tengo cuenta</a>
+      </div>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <span>©️ Gamification Journey</span>
+    <nav class="footer-links">
+      <a href="loginv2.html">Login</a>
+      <a href="signupv2.html">Crear cuenta</a>
+      <a href="#faq">FAQ</a>
+    </nav>
+  </footer>
+  <script type="module" src="../js/features/landing.js"></script>
+
+  </body>
+</html>
+
+
+

--- a/refactor/views/loginv2.refactor.html
+++ b/refactor/views/loginv2.refactor.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login — Gamification Journey</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="../../manifest.json">
+  <meta name="theme-color" content="#7d3cff">
+  <link rel="stylesheet" href="../css/base.css" />
+  <link rel="stylesheet" href="../css/layout.css" />
+
+</head>
+<body class="login-body">
+  <!-- Fondo con destellos (no interactúa) -->
+  <div class="bg" aria-hidden="true">
+    <div class="orb a"></div>
+    <div class="orb b"></div>
+    <div class="orb c"></div>
+  </div>
+
+  <!-- NAV -->
+  <div class="nav">
+    <a class="brand" href="indexv2.html" aria-label="Innerbloom — inicio">
+      <span class="brand-text">Innerbloom</span>
+      <img src="https://i.ibb.co/RpyF590p/innerbloom-white.png" alt="" class="logo-mark" width="32" height="32"> 
+    </a>
+  </div>
+
+  <!-- CONTENIDO (LOGIN) -->
+  <!-- Hook JS: #loginWrap se oculta cuando mostramos el modal de espera -->
+  <div class="wrap" id="loginWrap">
+    <div class="card">
+      <h1>Entrar al Dashboard</h1>
+      <p class="sub">
+        Ingresá tu correo. Si tu base ya está lista te llevo directo al
+        <strong>Dashboard</strong>. Si no, te muestro los pasos y espero con vos 👀.
+      </p>
+
+      <!-- Hook JS: #loginForm dispara login.js/features/login.js -->
+      <form id="loginForm" novalidate>
+        <div class="field">
+          <label for="email">Correo</label>
+          <input id="email" name="email" type="email" placeholder="tu@email.com" required />
+        </div>
+
+        <div class="actions">
+          <button id="goBtn" class="btn" type="submit">Continuar</button>
+          <a class="btn secondary" href="indexv2.html">Volver al inicio</a>
+        </div>
+
+        <!-- Hook JS: #status muestra mensajes amigables al usuario -->
+        <div id="status" class="status"></div>
+      </form>
+    </div>
+  </div>
+
+  <!-- AWAIT (solo con ?await=1 o cuando el status está “en proceso”) -->
+  <!-- Hook JS: #awaitModal muestra el estado "armando tu mundo" -->
+  <section id="awaitModal" class="wait-shell" role="dialog" aria-labelledby="awaitTitle" aria-hidden="true">
+    <div class="wait-card" role="document">
+      <button id="closeModal" class="close" title="Volver al login" aria-label="Volver al login">✕</button>
+
+      <h2 id="awaitTitle" class="wait-title">Preparando tu mundo…</h2>
+      <p class="wait-sub">
+        Estamos creando tu espacio. En unos minutos te llegará un
+        <strong>pergamino digital</strong> (un mail) para confirmar tu usuario.
+      </p>
+
+      <!-- TIP -->
+      <div class="wait-tip">
+        Tip: revisá también <strong>Spam/Promociones</strong> si el mail no aparece enseguida.
+      </div>
+
+      <!-- Próximos pasos (vertical, NO botones) -->
+      <div class="wait-section-title">Próximos pasos</div>
+      <ol class="next-steps" aria-label="Próximos pasos">
+        <li class="step-row"><span class="num">1</span><span class="step-text">Login</span></li>
+        <li class="step-row"><span class="num">2</span><span class="step-text">Confirmar BBDD</span></li>
+        <li class="step-row"><span class="num">3</span><span class="step-text">Programar Daily&nbsp;Quest</span></li>
+      </ol>
+
+      <!-- Mientras tanto (sí accionan) -->
+      <div class="wait-section-title">Mientras tanto</div>
+      <div class="wait-minor">
+        <button id="installBtn"   class="ghost" type="button">Instalar app</button>
+        <button id="copyLinkBtn"  class="ghost" type="button">Copiar link</button>
+        <a id="signupBtn" class="ghost" href="signupv2.html">Crear cuenta</a>
+        <a class="ghost" href="indexv2.html">Volver al inicio</a>
+      </div>
+
+      <!-- Ayuda iOS (plegable) -->
+      <details id="installHelp" class="wait-tip" style="margin-top:14px;">
+        <summary><strong>iPhone (Safari)</strong> — ¿Cómo instalar?</summary>
+        <ol style="margin:10px 0 0 18px;">
+          <li>Tocá <em>Compartir</em> (icono ↑).</li>
+          <li>Elegí <em>Agregar a inicio</em>.</li>
+          <li>Confirmá el nombre y guardá.</li>
+        </ol>
+      </details>
+    </div>
+  </section>
+
+  <!-- MODAL NOT-FOUND -->
+  <!-- Hook JS: #notFoundModal avisa cuando el correo no existe -->
+  <section id="notFoundModal" class="modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="nfTitle">
+    <div class="modal-card">
+      <button id="closeNF" class="close" title="Cerrar" aria-label="Cerrar">✕</button>
+      <h2 id="nfTitle" class="modal-title">❌ No encontramos tu cuenta</h2>
+
+      <div class="modal-body">
+        <p>No hay un usuario registrado con ese correo. Creá tu cuenta en un minuto y empezá tu Journey.</p>
+      </div>
+
+      <div class="modal-actions">
+        <a id="signupNF" class="btn" href="signupv2.html">Crear cuenta</a>
+        <button id="backNF" class="btn secondary" type="button">Volver</button>
+      </div>
+    </div>
+  </section>
+
+  <script type="module" src="../js/features/login.js"></script>
+
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add the refactor shadow folder with documentation, base/layout styles, and utility scaffolding
- duplicate the landing and login views into /refactor with annotated hooks and externalized CSS/JS
- modularize landing carousel and login workflow logic using the new DOM/a11y/net helpers and shared constants

## Testing
- not run (manual refactor)


------
https://chatgpt.com/codex/tasks/task_e_68de7b1e194c8322a45f4af1bb676067