### PR TITLE
Refactor signup and onboarding flows into modules

### DIFF
--- a/refactor/css/formsintrov2.css
+++ b/refactor/css/formsintrov2.css
@@ -1,0 +1,479 @@
+/* ==========================================================================
+   Vista: Forms Intro v2 (refactor)
+   Uso: estilos del wizard gamificado con HUD, pantallas y toasts.
+   Notas: calca la apariencia original y mantiene hooks para JS.
+   ========================================================================== */
+
+:root {
+  --bg: #0b0e19;
+  --panel: #141a2c;
+  --card: #171b31;
+  --ring: rgba(255, 255, 255, 0.08);
+  --text: #eaf0ff;
+  --muted: #a9b2d0;
+  --accent: #7a66ff;
+  --accent2: #a78bfa;
+  --ok: #38d39f;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.4);
+  --hudH: 64px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(1100px 700px at 50% -15%, rgba(122, 102, 255, 0.18), transparent 60%),
+    linear-gradient(180deg, #0b0e19, #0b0e19 30%, #0f1325 100%);
+  overflow: auto;
+  padding-top: calc(var(--hudH) + 10px);
+}
+
+/* ===== [HUD: barra superior con progreso] ===== */
+.hud {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 20;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1.2fr auto;
+  grid-template-areas: 'brand mid xp';
+  align-items: center;
+  padding: 10px 12px;
+  background: rgba(10, 12, 24, 0.86);
+  border-bottom: 1px solid var(--ring);
+  backdrop-filter: blur(4px);
+}
+
+.brand {
+  grid-area: brand;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+}
+
+.dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 20px var(--accent);
+}
+
+.journey {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.journey .progress {
+  width: 190px;
+}
+
+.mid {
+  grid-area: mid;
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+}
+
+.pill {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  min-width: 110px;
+}
+
+.pill .row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pill .emoji {
+  font-size: 14px;
+}
+
+.pill .label {
+  font-weight: 600;
+}
+
+progress {
+  width: 120px;
+  height: 8px;
+  background: #0f1430;
+  border-radius: 6px;
+}
+
+progress::-webkit-progress-bar {
+  background: #0f1430;
+  border-radius: 6px;
+}
+
+progress::-webkit-progress-value {
+  border-radius: 6px;
+  background: linear-gradient(90deg, #6d78ff, #a78bfa);
+}
+
+.xp {
+  grid-area: xp;
+  justify-self: end;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+}
+
+.progress {
+  height: 8px;
+  background: #0f1430;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.progress .fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), var(--accent2));
+}
+
+@media (max-width: 720px) {
+  :root {
+    --hudH: 104px;
+  }
+
+  .hud {
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'brand brand'
+      'mid xp';
+    row-gap: 8px;
+  }
+
+  .journey .progress {
+    width: 150px;
+  }
+
+  .pill {
+    min-width: auto;
+  }
+
+  progress {
+    width: 80px;
+  }
+}
+
+@media (max-width: 420px) {
+  .journey .progress {
+    width: 120px;
+  }
+
+  progress {
+    width: 64px;
+  }
+}
+
+/* ===== [Wizard: contenedor principal] ===== */
+.overlay {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.modal {
+  width: min(980px, 94vw);
+  background: rgba(20, 24, 44, 0.78);
+  border: 1px solid var(--ring);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  padding: 20px;
+  overflow: hidden;
+}
+
+.scr {
+  display: none;
+}
+
+.scr.active {
+  display: block;
+}
+
+.hero {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 1.05fr 0.95fr;
+  align-items: start;
+}
+
+@media (max-width: 980px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hero > .pic {
+  align-self: center;
+  justify-self: center;
+  margin: 8px auto;
+  max-width: 92%;
+}
+
+@media (max-width: 980px) {
+  .hero > .pic {
+    max-width: 100%;
+  }
+}
+
+.pic {
+  border-radius: 14px;
+  border: 1px solid var(--ring);
+  overflow: hidden;
+  background: #10142b;
+  justify-self: center;
+  max-width: 95%;
+}
+
+.pic img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 14px;
+  opacity: 0.96;
+}
+
+@media (min-width: 981px) {
+  .pic {
+    aspect-ratio: 4 / 3;
+    height: auto;
+    max-height: min(520px, calc(100vh - var(--hudH) - 140px));
+  }
+
+  .pic img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+@media (max-width: 980px) {
+  .pic {
+    height: auto;
+    max-height: clamp(260px, 42vh, 380px);
+  }
+
+  .pic img {
+    height: auto;
+    object-fit: cover;
+  }
+}
+
+@media (max-width: 420px) {
+  .pic {
+    max-height: 320px;
+  }
+}
+
+h1,
+h2 {
+  margin: 6px 0 10px;
+}
+
+p {
+  margin: 6px 0 12px;
+  color: #cbd3ff;
+  line-height: 1.65;
+}
+
+.note {
+  color: #aab7ff;
+  font-size: 13px;
+}
+
+.xp-badge {
+  display: inline-block;
+  font-size: 12px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  background: #101433;
+  border: 1px solid var(--ring);
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin: 12px 0;
+}
+
+.card {
+  background: #171b31;
+  border: 1px solid var(--ring);
+  border-radius: 14px;
+  padding: 14px;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+}
+
+.card.selected {
+  background: rgba(122, 102, 255, 0.22);
+  border-color: rgba(122, 102, 255, 0.45);
+}
+
+.checklist {
+  display: grid;
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.chip {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--ring);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+textarea,
+input[type='text'],
+input[type='email'] {
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--ring);
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  outline: none;
+}
+
+.open-title {
+  margin: 14px 0 8px;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: #e9edff;
+}
+
+.counter {
+  font-size: 13px;
+  color: #c7cff1;
+  margin-top: 6px;
+}
+
+.nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.btn {
+  background: #7a66ff;
+  border: 0;
+  color: #fff;
+  font-weight: 800;
+  padding: 10px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.btn.secondary {
+  background: transparent;
+  border: 1px solid var(--ring);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.summary-box {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--ring);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+/* ===== [Toast: XP y mensajes] ===== */
+.toast {
+  position: fixed;
+  right: 12px;
+  background: #111a39;
+  border: 1px solid var(--ring);
+  padding: 8px 10px;
+  border-radius: 9px;
+  font-size: 13px;
+  color: #cfe0ff;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 30;
+  pointer-events: none;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: none;
+}
+
+#toast13 {
+  bottom: 64px;
+}
+
+#toast21 {
+  bottom: 12px;
+}
+
+#toast {
+  bottom: 12px;
+}
+
+/* ===== [HUD: enlace interactivo] ===== */
+#hudTitle {
+  cursor: pointer;
+}
+
+#hudTitle:hover {
+  text-decoration: underline;
+}
+
+/* ===== [Botón: spinner inline] ===== */
+.btn.loading {
+  position: relative;
+}
+
+.btn.loading::after {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: transparent;
+  border-radius: 50%;
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: translateY(-50%) rotate(360deg);
+  }
+}

--- a/refactor/css/signupv2.css
+++ b/refactor/css/signupv2.css
@@ -1,0 +1,282 @@
+/* ==========================================================================
+   Vista: Signup v2 (refactor)
+   Uso: estilos específicos del formulario de creación de cuenta.
+   Notas: replica la apariencia original, listo para seguir modularizando.
+   ========================================================================== */
+
+:root {
+  --bg: #0b0f19;
+  --card: #121829;
+  --ink: #e8ecf1;
+  --muted: #9aa3b2;
+  --accent: #7d3cff;
+  --accent-2: #5c28c2;
+  --line: rgba(255, 255, 255, 0.14);
+}
+
+/* ===== [Signup: estructura base] =====
+   Cuerpo con gradientes y tipografía Rubik para mantener la identidad. */
+body.signupv2 {
+  font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', Inter, Roboto, Arial, sans-serif;
+  background:
+    radial-gradient(1200px 800px at 20% -10%, #1a2340 0%, rgba(26, 35, 64, 0) 60%),
+    radial-gradient(1000px 700px at 120% 0%, #321a63 0%, rgba(50, 26, 99, 0) 60%),
+    var(--bg);
+  color: var(--ink);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ===== [Signup: navegación superior] ===== */
+.nav {
+  width: 100%;
+  background: rgba(18, 24, 41, 0.6);
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  position: sticky;
+  top: 0;
+  z-index: 40;
+}
+
+.brand {
+  color: #fff;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.nav-actions {
+  display: flex;
+  gap: 10px;
+}
+
+/* ===== [Signup: botones reutilizables] ===== */
+.btn {
+  appearance: none;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 800;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  text-decoration: none;
+  transition: 0.2s background, 0.05s transform;
+}
+
+.btn:hover {
+  background: var(--accent-2);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn.ghost,
+.btn.secondary {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+
+/* ===== [Signup: layout de la tarjeta] ===== */
+.wrap {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.card {
+  width: 100%;
+  max-width: 760px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 24px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 26px;
+  font-weight: 900;
+  text-align: center;
+}
+
+.sub {
+  margin: 0 0 16px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.status {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+  min-height: 20px;
+}
+
+/* ===== [Signup: campos en grilla] ===== */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.field label {
+  display: block;
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.field input,
+.field select {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: #0f1526;
+  color: var(--ink);
+  outline: none;
+}
+
+.field input::placeholder {
+  color: #7f8aa3;
+}
+
+/* ===== [Signup: bloque de avatar] ===== */
+.avatar-block {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+#avatar-preview {
+  width: 200px;
+  height: 300px;
+  object-fit: cover;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.file-label {
+  cursor: pointer;
+}
+
+.tiny {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ===== [Signup: modal de estados] ===== */
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 100;
+}
+
+.modal.visible {
+  display: grid;
+}
+
+.modal-card {
+  width: 100%;
+  max-width: 720px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 18px;
+  position: relative;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+}
+
+.close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  color: #cfd6ec;
+  background: transparent;
+}
+
+.close:hover {
+  border-color: #fff;
+  color: #fff;
+}
+
+.modal-title {
+  margin: 0 0 6px;
+  font-weight: 900;
+  font-size: 20px;
+}
+
+.modal-body {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-top: 14px;
+}
+
+/* ===== [Signup: spinner reutilizable] ===== */
+.spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #fff;
+  animation: spin 0.9s linear infinite;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 900px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/refactor/js/features/formsintrov2.js
+++ b/refactor/js/features/formsintrov2.js
@@ -1,0 +1,847 @@
+/**
+ * Módulo: FormsIntroV2
+ * Propósito: encapsular el wizard de onboarding y su envío final.
+ * API pública: se inicializa solo al cargar la página.
+ * Dependencias: utils/dom, utils/net.
+ * Comentarios en modo “cuento para peques”.
+ */
+
+import {
+  byId,
+  qsa,
+  on,
+  delegate,
+  setHTML,
+  setText,
+  createElement,
+} from '../utils/dom.js';
+import { postJson } from '../utils/net.js';
+
+const WORKER_URL = 'https://gamificationonboarding.rfullivarri22.workers.dev/';
+const REDIRECT_URL = 'https://rfullivarri.github.io/gamificationweblanding/loginv2.html?await=1';
+
+const FORM_LABELS = {
+  lowBody: [
+    'Dormir mejor 😴',
+    'Alimentarte mejor 🥗',
+    'Moverte un poco más 🏃',
+    'Tomar más agua 💧',
+    'Descansar sin culpa 🧘',
+  ],
+  lowSoul: [
+    'Respirar profundo unos minutos 🌬️',
+    'Escuchar música que te gusta 🎶',
+    'Estar en contacto con la naturaleza 🍃',
+    'Anotar lo que sentís en un papel 📝',
+    'Hacer algo sin tener que ser útil 🌈',
+  ],
+  lowMind: [
+    'Leer algo corto 📖',
+    'Anotar tus pensamientos 📓',
+    'Mirar una serie tranquila 📺',
+    'Hacer una pausa sin pantallas 🚫📱',
+    'Desarmar alguna idea negativa 🧩',
+  ],
+  chillMotiv: [
+    '🌱 Crecer como persona / desarrollo personal',
+    '🎯 Lograr metas concretas que me propongo',
+    '🤝 Sentirme más conectado con otras personas',
+    '🧘‍♂️ Vivir con más calma y menos estrés',
+    '🏆 Superarme a mí mismo y romper mis límites',
+    '🛠️ Crear o construir algo (proyectos, arte, emprendimientos)',
+    '✨ Sentirme más feliz y satisfecho con mi día a día',
+    '🗺️ Tener más experiencias y aventuras',
+    '💖 Cuidar mi salud y bienestar a largo plazo',
+  ],
+  flowObstacles: [
+    'Falta de tiempo',
+    'Falta de energía o motivación',
+    'Miedo al fracaso',
+    'Dudas sobre dónde empezar',
+    'Falta de apoyo',
+    'Procrastinación',
+    'No tengo Hábitos aún',
+    'Síndrome del impostor',
+  ],
+  evolveCommit: [
+    'Mis hábitos diarios',
+    'Mi alimentación',
+    'Mis rutinas de descanso',
+    'Mi tiempo libre',
+    'Mis relaciones sociales',
+    'Mis creencias y bloqueos mentales',
+    'Mis espacios físicos',
+  ],
+  evolveAtt: [
+    'Estoy muy motivado y quiero cambios ya',
+    'Quiero ir de a poco pero con foco',
+    'Me cuesta mantener constancia pero quiero intentar',
+  ],
+  fBody: [
+    '🏃‍♂️ Actividad física regular (Energía)',
+    '🥗 Alimentación saludable (Nutrición)',
+    '😴 Dormir y descansar mejor (Sueño)',
+    '🛀 Relajación y pausas para recuperar el cuerpo (Recuperación)',
+    '💧 Tomar más agua o hidratarte mejor (Hidratación)',
+    '🧼 Higiene y cuidado personal diario (Higiene)',
+    '🌅 Sentirte con más energía y vitalidad al despertar (Vitalidad)',
+    '💺 Mejorar tu postura y ergonomía (Postura)',
+    '🧘‍♂️ Flexibilidad y movilidad corporal (Movilidad)',
+    '🚫 Reducir consumo de alcohol, tabaco o cafeína (Moderación)',
+  ],
+  fSoul: [
+    '🤝 Fortalecer relaciones y vínculos personales (Conexión)',
+    '🌌 Practicar espiritualidad o sentir plenitud interior (Espiritualidad)',
+    '🎯 Definir tu propósito y dirección en la vida (Propósito)',
+    '⚖️ Vivir más alineado a tus valores (Valores)',
+    '💗 Ayudar a otros o aportar a una causa (Altruismo)',
+    '🔍 Conocerte más profundamente (Insight)',
+    '🙏 Practicar gratitud o tener una actitud positiva (Gratitud)',
+    '🌳 Conectarte más con la naturaleza (Naturaleza)',
+    '🎉 Jugar, reír y divertirte sin culpa (Gozo)',
+    '🪞 Trabajar tu autoestima y hablarte con más amabilidad (Autoestima)',
+  ],
+  fMind: [
+    '🎯 Mejorar tu enfoque y productividad diaria (Enfoque)',
+    '📚 Aprender cosas nuevas o estudiar mejor (Aprendizaje)',
+    '🎨 Desarrollar tu creatividad e ideas nuevas (Creatividad)',
+    '😵‍💫 Manejar mejor el estrés o ansiedad (Gestión)',
+    '🧠 Regular tus emociones y reacciones (Autocontrol)',
+    '💪 Ser más resiliente frente a desafíos (Resiliencia)',
+    '🗂️ Tener tus tareas o espacios mentales más organizados (Orden)',
+    '🚀 Desarrollarte profesionalmente o avanzar en tu carrera (Proyección)',
+    '💰 Mejorar tus hábitos financieros (Finanzas)',
+    '🧩 Ejercitar tu memoria y agilidad mental (Agilidad)',
+  ],
+};
+
+const MODE_LABELS = {
+  LOW: 'Low Mood 🪫 - Quiero un cambio, pero no tengo la energia',
+  CHILL: 'Chill Mood 🌿 - Estoy  bien, quiero trackear mis hábitos',
+  FLOW: 'Flow Mood 🌊 - Tengo un objetivo y quiero comenzar esta aventura',
+  EVOLVE: 'Evolve Mood 🧬 - Estoy enfocado y quiero ir al próximo nivel',
+};
+
+const state = {
+  xp: { Body: 0, Mind: 0, Soul: 0, total: 0 },
+  answers: {
+    email: '',
+    mode: null,
+    low: { body: [], soul: [], mind: [], note: '' },
+    chill: { oneThing: '', motiv: [] },
+    flow: { goal: '', imped: [] },
+    evolve: { goal: '', trade: [], att: '' },
+    foundations: { body: [], soul: [], mind: [], bodyOpen: '', soulOpen: '', mindOpen: '' },
+  },
+  routeScreens: [],
+  stepIndex: 0,
+  sending: false,
+};
+
+const LISTS = {
+  lowBody: FORM_LABELS.lowBody,
+  lowSoul: FORM_LABELS.lowSoul,
+  lowMind: FORM_LABELS.lowMind,
+  chillMotiv: FORM_LABELS.chillMotiv,
+  flowImped: FORM_LABELS.flowObstacles,
+  evolveTrade: FORM_LABELS.evolveCommit,
+  evolveAtt: FORM_LABELS.evolveAtt,
+  fBody: FORM_LABELS.fBody,
+  fSoul: FORM_LABELS.fSoul,
+  fMind: FORM_LABELS.fMind,
+};
+
+const OPEN_FOUND = {
+  'scr-f-body': 'fBodyOpen2',
+  'scr-f-soul': 'fSoulOpen2',
+  'scr-f-mind': 'fMindOpen2',
+};
+
+function $$(selector, scope = document) {
+  return qsa(selector, scope);
+}
+
+function toast(message) {
+  const toastEl = byId('toast');
+  if (!toastEl) return;
+  setText(toastEl, message);
+  toastEl.classList.add('show');
+  window.setTimeout(() => toastEl.classList.remove('show'), 1100);
+}
+
+function drawProgress() {
+  const total = state.routeScreens.length;
+  let pct = 0;
+  if (total > 1) {
+    pct = Math.min(100, Math.max(0, Math.round((state.stepIndex / (total - 1)) * 100)));
+  }
+  const fill = byId('progressFill');
+  if (fill) fill.style.width = `${pct}%`;
+
+  const barBody = byId('barBody');
+  const barMind = byId('barMind');
+  const barSoul = byId('barSoul');
+  if (barBody) barBody.value = Math.min(Math.round(state.xp.Body), 100);
+  if (barMind) barMind.value = Math.min(Math.round(state.xp.Mind), 100);
+  if (barSoul) barSoul.value = Math.min(Math.round(state.xp.Soul), 100);
+
+  const xpTotal = byId('xpTotal');
+  if (xpTotal) setText(xpTotal, Math.round(state.xp.Body + state.xp.Mind + state.xp.Soul));
+}
+
+function addXP(amount, pillar) {
+  if (amount <= 0) return;
+  const fix = (num) => Math.round(num * 100) / 100;
+  if (pillar === 'ALL') {
+    ['Body', 'Mind', 'Soul'].forEach((key) => {
+      state.xp[key] = fix(state.xp[key] + amount / 3);
+    });
+  } else {
+    state.xp[pillar] = fix(state.xp[pillar] + amount);
+  }
+  state.xp.total = fix(state.xp.Body + state.xp.Mind + state.xp.Soul);
+  drawProgress();
+}
+
+function showScreen(id) {
+  $$('.scr').forEach((section) => section.classList.remove('active'));
+  const section = byId(id);
+  if (section) section.classList.add('active');
+  drawProgress();
+}
+
+function goToScreen(id) {
+  const idx = state.routeScreens.indexOf(id);
+  if (idx >= 0) {
+    state.stepIndex = idx;
+  }
+  showScreen(id);
+}
+
+function nextStep() {
+  const next = Math.min(state.routeScreens.length - 1, state.stepIndex + 1);
+  state.stepIndex = next;
+  const target = state.routeScreens[next];
+  if (target) {
+    showScreen(target);
+    if (target === 'scr-summary') {
+      renderSummary();
+    }
+  }
+}
+
+function prevStep() {
+  state.stepIndex = Math.max(0, state.stepIndex - 1);
+  const target = state.routeScreens[state.stepIndex];
+  if (target) showScreen(target);
+}
+
+function doOnce(sectionId, action) {
+  const section = byId(sectionId);
+  if (!section) return;
+  if (section.dataset.done === '1') {
+    nextStep();
+    return;
+  }
+  action();
+  section.dataset.done = '1';
+  nextStep();
+}
+
+function paintChecklist(listId, items, type = 'checkbox', nameGroup = 'grp') {
+  const host = byId(listId);
+  if (!host) return;
+  setHTML(host, '');
+  items.forEach((text, index) => {
+    const inputId = `${listId}-${index}`;
+    const label = createElement('label', { className: 'chip' });
+    label.setAttribute('for', inputId);
+    const input = createElement('input', { type });
+    if (type === 'radio') input.name = nameGroup;
+    input.id = inputId;
+    const span = createElement('span', { textContent: text });
+    label.appendChild(input);
+    label.appendChild(span);
+    host.appendChild(label);
+  });
+}
+
+function getCheckedTexts(scopeSelector) {
+  return $$(`${scopeSelector} input:checked`).map((input) => {
+    const parent = input.parentElement;
+    return parent ? parent.textContent.trim() : '';
+  });
+}
+
+function getRadioText(scopeSelector) {
+  const match = $$( `${scopeSelector} input[type="radio"]` ).find((input) => input.checked);
+  return match ? match.parentElement.textContent.trim() : '';
+}
+
+function bindLimitedChecklist(sectionId, listId, countId, storeArrRef, openTextareaId = null) {
+  const section = byId(sectionId);
+  if (!section) return;
+  const max = Number(section.dataset.limit || 5);
+  const inputs = $$( `#${listId} input` );
+  const counter = byId(countId);
+
+  const confirmMap = {
+    'scr-low-body': 'confirmLowBody',
+    'scr-low-soul': 'confirmLowSoul',
+    'scr-low-mind': 'confirmLowMind',
+    'scr-f-body': 'confirmFBody',
+    'scr-f-soul': 'confirmFSoul',
+    'scr-f-mind': 'confirmFMind',
+  };
+  const confirmBtn = byId(confirmMap[sectionId]);
+  if (!confirmBtn) return;
+
+  function update() {
+    const selected = inputs.filter((input) => input.checked);
+    if (selected.length > max) {
+      selected[selected.length - 1].checked = false;
+    }
+    const current = inputs.filter((input) => input.checked).length;
+    if (counter) setText(counter, String(current));
+    confirmBtn.disabled = current < 1;
+  }
+
+  inputs.forEach((input) => on(input, 'change', update));
+  update();
+
+  on(confirmBtn, 'click', () => {
+    if (openTextareaId) {
+      const textarea = byId(openTextareaId);
+      const value = textarea?.value.trim() || '';
+      const keyMap = {
+        'scr-f-body': 'bodyOpen',
+        'scr-f-soul': 'soulOpen',
+        'scr-f-mind': 'mindOpen',
+        'scr-low-body': 'bodyOpen',
+        'scr-low-soul': 'soulOpen',
+        'scr-low-mind': 'mindOpen',
+      };
+      const key = keyMap[sectionId];
+      if (key) state.answers.foundations[key] = value;
+      if (value && section.dataset.openDone !== '1') {
+        addXP(21, 'ALL');
+        toast('+21 XP');
+        section.dataset.openDone = '1';
+      }
+    }
+
+    if (section.dataset.done !== '1') {
+      storeArrRef.length = 0;
+      getCheckedTexts(`#${listId}`).forEach((text) => storeArrRef.push(text));
+      const xpValue = Number(section.dataset.xp || 13);
+      const pillar = section.dataset.pillar;
+      addXP(xpValue, pillar);
+      toast(`+${xpValue} XP`);
+      section.dataset.done = '1';
+    }
+    nextStep();
+  });
+}
+
+function resetAll() {
+  state.xp = { Body: 0, Mind: 0, Soul: 0, total: 0 };
+  state.answers = {
+    email: '',
+    mode: null,
+    low: { body: [], soul: [], mind: [], note: '' },
+    chill: { oneThing: '', motiv: [] },
+    flow: { goal: '', imped: [] },
+    evolve: { goal: '', trade: [], att: '' },
+    foundations: { body: [], soul: [], mind: [], bodyOpen: '', soulOpen: '', mindOpen: '' },
+  };
+  state.routeScreens = [];
+  state.stepIndex = 0;
+  state.sending = false;
+
+  $$("input[type='email'], input[type='text'], textarea").forEach((el) => { el.value = ''; });
+  $$("input[type='checkbox'], input[type='radio']").forEach((el) => { el.checked = false; });
+  $$('.card.selected').forEach((card) => card.classList.remove('selected'));
+  [
+    'confirmMode', 'confirmChillOpen', 'confirmFlowGoal', 'confirmEvolveGoal',
+    'confirmChillMotiv', 'confirmFlowImped', 'confirmEvolveTrade', 'confirmEvolveAtt',
+    'confirmLowBody', 'confirmLowSoul', 'confirmLowMind', 'confirmFBody', 'confirmFSoul', 'confirmFMind',
+  ].forEach((id) => {
+    const btn = byId(id);
+    if (btn) btn.disabled = true;
+  });
+  $$('.scr').forEach((section) => {
+    delete section.dataset.done;
+    delete section.dataset.openDone;
+  });
+  drawProgress();
+  showScreen('scr-intro');
+}
+
+function renderSummary() {
+  const box = byId('summaryBox');
+  if (!box) return;
+  const fmt = (arr) => (arr && arr.length ? arr.join(', ') : '—');
+  const { answers, xp } = state;
+
+  const lowBlock = `
+    <div><strong>LOW · Body:</strong> ${fmt(answers.low.body)}</div>
+    <div><strong>LOW · Soul:</strong> ${fmt(answers.low.soul)}</div>
+    <div><strong>LOW · Mind:</strong> ${fmt(answers.low.mind)}</div>
+    ${answers.low.note ? `<div><strong>Nota:</strong> ${answers.low.note}</div>` : ''}
+  `;
+
+  const modeBlocks = `
+    ${answers.mode === 'CHILL' ? `<div><strong>CHILL · Objetivo:</strong> ${answers.chill.oneThing}</div><div><strong>CHILL · Motivaciones:</strong> ${fmt(answers.chill.motiv)}</div>` : ''}
+    ${answers.mode === 'FLOW' ? `<div><strong>FLOW · Objetivo:</strong> ${answers.flow.goal}</div><div><strong>FLOW · Impedimentos:</strong> ${fmt(answers.flow.imped)}</div>` : ''}
+    ${answers.mode === 'EVOLVE' ? `<div><strong>EVOLVE · Objetivo:</strong> ${answers.evolve.goal}</div><div><strong>EVOLVE · Ajustes:</strong> ${fmt(answers.evolve.trade)}</div><div><strong>EVOLVE · Actitud:</strong> ${answers.evolve.att}</div>` : ''}
+    <hr style="border:0;border-top:1px solid var(--ring);margin:8px 0">
+    <div><strong>Foundations · Body:</strong> ${fmt(answers.foundations.body)}</div>
+    <div><strong>Foundations · Soul:</strong> ${fmt(answers.foundations.soul)}</div>
+    <div><strong>Foundations · Mind:</strong> ${fmt(answers.foundations.mind)}</div>
+  `;
+
+  const summaryHtml = `
+    <div><strong>Game Mode:</strong> ${answers.mode || '—'}</div>
+    <div><strong>Email:</strong> ${answers.email || '—'}</div>
+    <hr style="border:0;border-top:1px solid var(--ring);margin:8px 0">
+    ${answers.mode === 'LOW' ? lowBlock : modeBlocks}
+    <hr style="border:0;border-top:1px solid var(--ring);margin:8px 0">
+    <div><strong>🫀 Body:</strong> ${Math.round(xp.Body)} XP</div>
+    <div><strong>🧠 Mind:</strong> ${Math.round(xp.Mind)} XP</div>
+    <div><strong>🏵️ Soul:</strong> ${Math.round(xp.Soul)} XP</div>
+    <div style="margin-top:6px"><strong>Total:</strong> ${Math.round(xp.total)} XP</div>
+  `;
+  setHTML(box, summaryHtml);
+}
+
+function buildRoutes() {
+  const routes = {
+    LOW: ['scr-low-body', 'scr-low-soul', 'scr-low-mind', 'scr-low-note', 'scr-summary'],
+    CHILL: ['scr-chill-open', 'scr-chill-motiv', 'scr-f-body', 'scr-f-soul', 'scr-f-mind', 'scr-summary'],
+    FLOW: ['scr-flow-goal', 'scr-flow-imped', 'scr-f-body', 'scr-f-soul', 'scr-f-mind', 'scr-summary'],
+    EVOLVE: ['scr-evolve-goal', 'scr-evolve-trade', 'scr-evolve-att', 'scr-f-body', 'scr-f-soul', 'scr-f-mind', 'scr-summary'],
+  };
+  state.routeScreens = routes[state.answers.mode] || [];
+  state.stepIndex = 0;
+  const first = state.routeScreens[0] || 'scr-intro';
+  goToScreen(first);
+}
+
+function handleModeSelection(card, mode) {
+  $$('#modeGrid .card').forEach((node) => node.classList.remove('selected'));
+  card.classList.add('selected');
+  const confirm = byId('confirmMode');
+  if (confirm) confirm.disabled = false;
+  state.answers.mode = mode;
+}
+
+function setupModeGrid() {
+  const grid = byId('modeGrid');
+  if (grid) {
+    delegate(grid, 'click', '.card', (event, card) => {
+      const mode = card.dataset.mode;
+      if (!mode) return;
+      handleModeSelection(card, mode);
+    });
+  }
+
+  const confirmMode = byId('confirmMode');
+  if (confirmMode) {
+    on(confirmMode, 'click', () => {
+      if (!state.answers.mode) return;
+      const label = MODE_LABELS[state.answers.mode];
+      if (label) state.answers.modeLabel = label;
+      const startScreens = {
+        LOW: 'scr-low-body',
+        CHILL: 'scr-chill-open',
+        FLOW: 'scr-flow-goal',
+        EVOLVE: 'scr-evolve-goal',
+      };
+      buildRoutes();
+      goToScreen(startScreens[state.answers.mode]);
+    });
+  }
+}
+
+function setupEmailIntro() {
+  const emailInput = byId('emailInput');
+  const goBtn = byId('goModes');
+  if (!emailInput || !goBtn) return;
+  if (String(goBtn.tagName).toUpperCase() === 'BUTTON') goBtn.type = 'button';
+  const normalize = (value) => String(value || '').trim().toLowerCase();
+  const isEmail = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+  function refresh() {
+    const val = normalize(emailInput.value);
+    const ok = isEmail(val);
+    goBtn.disabled = !ok;
+    state.answers.email = val;
+    window.GJ_EMAIL = val;
+  }
+
+  ['input', 'change', 'paste', 'blur', 'compositionend'].forEach((evt) => {
+    on(emailInput, evt, refresh);
+  });
+
+  on(goBtn, 'click', () => {
+    if (goBtn.disabled) return;
+    buildRoutes();
+    goToScreen(state.routeScreens[0] || 'scr-modes');
+  });
+
+  refresh();
+}
+
+function setupTextAreas() {
+  const lowNote = byId('lowNote');
+  const confirmLowNote = byId('confirmLowNote');
+  if (confirmLowNote) {
+    on(confirmLowNote, 'click', () => {
+      doOnce('scr-low-note', () => {
+        const value = lowNote?.value.trim() || '';
+        state.answers.low.note = value;
+        if (value) {
+          const xpValue = Number(byId('scr-low-note')?.dataset?.xp || 21);
+          addXP(xpValue, 'ALL');
+          toast(`+${xpValue} XP`);
+        }
+      });
+    });
+  }
+
+  const chillOneThing = byId('chillOneThing');
+  const confirmChillOpen = byId('confirmChillOpen');
+  if (chillOneThing && confirmChillOpen) {
+    const update = () => {
+      const value = chillOneThing.value.trim();
+      confirmChillOpen.disabled = value.length < 1;
+    };
+    on(chillOneThing, 'input', update);
+    update();
+    on(confirmChillOpen, 'click', () => {
+      doOnce('scr-chill-open', () => {
+        state.answers.chill.oneThing = chillOneThing.value.trim();
+        addXP(21, 'ALL');
+        toast('+21 XP');
+      });
+    });
+  }
+
+  const flowGoal = byId('flowGoal');
+  const confirmFlowGoal = byId('confirmFlowGoal');
+  if (flowGoal && confirmFlowGoal) {
+    const update = () => {
+      confirmFlowGoal.disabled = flowGoal.value.trim().length < 1;
+    };
+    on(flowGoal, 'input', update);
+    update();
+    on(confirmFlowGoal, 'click', () => {
+      doOnce('scr-flow-goal', () => {
+        state.answers.flow.goal = flowGoal.value.trim();
+        addXP(21, 'ALL');
+        toast('+21 XP');
+      });
+    });
+  }
+
+  const evolveGoal = byId('evolveGoal');
+  const confirmEvolveGoal = byId('confirmEvolveGoal');
+  if (evolveGoal && confirmEvolveGoal) {
+    const update = () => {
+      confirmEvolveGoal.disabled = evolveGoal.value.trim().length < 1;
+    };
+    on(evolveGoal, 'input', update);
+    update();
+    on(confirmEvolveGoal, 'click', () => {
+      doOnce('scr-evolve-goal', () => {
+        state.answers.evolve.goal = evolveGoal.value.trim();
+        addXP(21, 'ALL');
+        toast('+21 XP');
+      });
+    });
+  }
+}
+
+function setupModeLists() {
+  const chillInputs = $$('#chillMotivList input');
+  const confirmChillMotiv = byId('confirmChillMotiv');
+  if (confirmChillMotiv) {
+    const update = () => {
+      confirmChillMotiv.disabled = chillInputs.filter((i) => i.checked).length < 1;
+    };
+    chillInputs.forEach((input) => on(input, 'change', update));
+    update();
+    on(confirmChillMotiv, 'click', () => {
+      doOnce('scr-chill-motiv', () => {
+        state.answers.chill.motiv = getCheckedTexts('#chillMotivList');
+        addXP(13, 'ALL');
+        toast('+13 XP');
+      });
+    });
+  }
+
+  const flowInputs = $$('#flowImpedList input');
+  const confirmFlowImped = byId('confirmFlowImped');
+  if (confirmFlowImped) {
+    const update = () => {
+      confirmFlowImped.disabled = flowInputs.filter((i) => i.checked).length < 1;
+    };
+    flowInputs.forEach((input) => on(input, 'change', update));
+    update();
+    on(confirmFlowImped, 'click', () => {
+      doOnce('scr-flow-imped', () => {
+        state.answers.flow.imped = getCheckedTexts('#flowImpedList');
+        addXP(13, 'ALL');
+        toast('+13 XP');
+      });
+    });
+  }
+
+  const evolveTradeInputs = $$('#evolveTradeList input');
+  const confirmEvolveTrade = byId('confirmEvolveTrade');
+  if (confirmEvolveTrade) {
+    const update = () => {
+      confirmEvolveTrade.disabled = evolveTradeInputs.filter((i) => i.checked).length < 1;
+    };
+    evolveTradeInputs.forEach((input) => on(input, 'change', update));
+    update();
+    on(confirmEvolveTrade, 'click', () => {
+      doOnce('scr-evolve-trade', () => {
+        state.answers.evolve.trade = getCheckedTexts('#evolveTradeList');
+        addXP(13, 'ALL');
+        toast('+13 XP');
+      });
+    });
+  }
+
+  const evolveAttInputs = $$('#evolveAttList input');
+  const confirmEvolveAtt = byId('confirmEvolveAtt');
+  if (confirmEvolveAtt) {
+    const update = () => {
+      confirmEvolveAtt.disabled = !evolveAttInputs.some((i) => i.checked);
+    };
+    evolveAttInputs.forEach((input) => on(input, 'change', update));
+    update();
+    on(confirmEvolveAtt, 'click', () => {
+      doOnce('scr-evolve-att', () => {
+        state.answers.evolve.att = getRadioText('#evolveAttList');
+        addXP(21, 'ALL');
+        toast('+21 XP');
+      });
+    });
+  }
+}
+
+function setupNavigation() {
+  on(document, 'keydown', (event) => {
+    if (event.key === 'ArrowLeft') prevStep();
+    if (event.key === 'ArrowRight') nextStep();
+  });
+
+  const restart = byId('restart');
+  if (restart) on(restart, 'click', resetAll);
+
+  const hudTitle = byId('hudTitle');
+  if (hudTitle) {
+    on(hudTitle, 'click', () => {
+      if (!state.xp.total || window.confirm('¿Salir y volver al inicio? Se perderá el progreso.')) {
+        window.location.href = 'https://rfullivarri.github.io/gamificationweblanding/indexv2.html';
+      }
+    });
+  }
+
+  const backIntro = byId('backIntro') || byId('backToIntro');
+  if (backIntro) on(backIntro, 'click', () => showScreen('scr-intro'));
+
+  const goToMap = {
+    backToModes1: 'scr-modes',
+    backToModes2: 'scr-modes',
+    backToModes3: 'scr-modes',
+    backToModes4: 'scr-modes',
+    backEvolveGoal: 'scr-evolve-goal',
+  };
+  Object.entries(goToMap).forEach(([id, target]) => {
+    const btn = byId(id);
+    if (btn) on(btn, 'click', () => goToScreen(target));
+  });
+
+  const prevIds = [
+    'backLowBody',
+    'backLowSoul',
+    'backLowMind',
+    'backChillOpen',
+    'backFlowGoal',
+    'backEvolveTrade',
+    'backFoundPrev1',
+    'backFBody',
+    'backFSoul',
+  ];
+  prevIds.forEach((id) => {
+    const btn = byId(id);
+    if (btn) on(btn, 'click', prevStep);
+  });
+}
+
+function setupFoundationsOpens() {
+  Object.entries(OPEN_FOUND).forEach(([sectionId, textareaId]) => {
+    const textarea = byId(textareaId);
+    if (!textarea) return;
+    on(textarea, 'blur', () => {
+      const value = textarea.value.trim();
+      const mapKey = { 'scr-f-body': 'bodyOpen', 'scr-f-soul': 'soulOpen', 'scr-f-mind': 'mindOpen' }[sectionId];
+      if (mapKey) state.answers.foundations[mapKey] = value;
+    });
+  });
+}
+
+function setupChecklistBindings() {
+  bindLimitedChecklist('scr-low-body', 'lowBodyList', 'lowBodyCount', state.answers.low.body, 'fBodyOpen');
+  bindLimitedChecklist('scr-low-soul', 'lowSoulList', 'lowSoulCount', state.answers.low.soul, 'fSoulOpen');
+  bindLimitedChecklist('scr-low-mind', 'lowMindList', 'lowMindCount', state.answers.low.mind, 'fMindOpen');
+  bindLimitedChecklist('scr-f-body', 'fBodyList', 'fBodyCount', state.answers.foundations.body, 'fBodyOpen2');
+  bindLimitedChecklist('scr-f-soul', 'fSoulList', 'fSoulCount', state.answers.foundations.soul, 'fSoulOpen2');
+  bindLimitedChecklist('scr-f-mind', 'fMindList', 'fMindCount', state.answers.foundations.mind, 'fMindOpen2');
+}
+
+async function sendPayload() {
+  if (state.sending) return;
+  state.sending = true;
+  const finishBtn = byId('finish');
+  if (!finishBtn) {
+    state.sending = false;
+    return;
+  }
+
+  const originalText = finishBtn.textContent;
+  finishBtn.disabled = true;
+  finishBtn.classList.add('loading');
+  finishBtn.setAttribute('aria-busy', 'true');
+  finishBtn.textContent = 'Enviando…';
+
+  try {
+    const payload = window.GJPayload?.build?.();
+    if (!payload) throw new Error('payload_build_failed');
+    if (!payload.email) throw new Error('email_required');
+    if (!payload.mode) throw new Error('mode_required');
+
+    const response = await postJson(WORKER_URL, payload);
+    if (!response || response.ok === false) {
+      throw new Error(response?.error || 'worker_error');
+    }
+
+    try {
+      sessionStorage.setItem('gj_email', payload.email || '');
+      sessionStorage.setItem('gj_client_id', response.client_id || payload.client_id || '');
+      window._lastClientId = response.client_id || payload.client_id || '';
+    } catch (_error) {
+      // continuar igual
+    }
+
+    window.location.href = REDIRECT_URL;
+  } catch (error) {
+    console.error('[onboarding] send error:', error);
+    toast('No pudimos enviar. Probá de nuevo.');
+    finishBtn.classList.remove('loading');
+    finishBtn.removeAttribute('aria-busy');
+    finishBtn.disabled = false;
+    finishBtn.textContent = originalText;
+    state.sending = false;
+  }
+}
+
+function buildPayloadHelpers() {
+  const keyCID = 'gj_client_id';
+
+  function getClientId() {
+    try {
+      let cid = localStorage.getItem(keyCID);
+      if (!cid) {
+        cid = window.crypto?.randomUUID ? window.crypto.randomUUID() : `cid-${Math.random().toString(36).slice(2)}${Date.now()}`;
+        localStorage.setItem(keyCID, cid);
+      }
+      return cid;
+    } catch (_error) {
+      return `cid-${Date.now()}`;
+    }
+  }
+
+  function meta() {
+    let tz = '';
+    try {
+      tz = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+    } catch (_error) {
+      tz = '';
+    }
+    const lang = (navigator.language || '').toLowerCase();
+    const ua = (navigator.userAgent || '').toLowerCase();
+    const device = /mobi|android/.test(ua) ? 'mobile' : 'desktop';
+    return { tz, lang, device, version: 'formsintrov2' };
+  }
+
+  window.JOURNEY_STATE = {
+    get answers() {
+      return state.answers;
+    },
+    get xp() {
+      return state.xp;
+    },
+  };
+
+  window.GJPayload = {
+    build() {
+      const answers = window.JOURNEY_STATE?.answers || {};
+      const xp = window.JOURNEY_STATE?.xp || { Body: 0, Mind: 0, Soul: 0, total: 0 };
+      const payload = {
+        email: answers.email,
+        mode: answers.mode,
+        mode_label: MODE_LABELS[answers.mode] || '',
+        answers,
+        xp,
+        meta: meta(),
+        client_id: getClientId(),
+        timestamp: new Date().toISOString(),
+      };
+      return payload;
+    },
+  };
+}
+
+function setupFinishButton() {
+  const finish = byId('finish');
+  if (finish) on(finish, 'click', (event) => {
+    event.preventDefault();
+    sendPayload();
+  });
+}
+
+function mountLists() {
+  paintChecklist('lowBodyList', LISTS.lowBody);
+  paintChecklist('lowSoulList', LISTS.lowSoul);
+  paintChecklist('lowMindList', LISTS.lowMind);
+  paintChecklist('fBodyList', LISTS.fBody);
+  paintChecklist('fSoulList', LISTS.fSoul);
+  paintChecklist('fMindList', LISTS.fMind);
+  paintChecklist('chillMotivList', LISTS.chillMotiv);
+  paintChecklist('flowImpedList', LISTS.flowImped);
+  paintChecklist('evolveTradeList', LISTS.evolveTrade);
+  paintChecklist('evolveAttList', LISTS.evolveAtt, 'radio', 'evolveAtt');
+}
+
+function init() {
+  mountLists();
+  setupChecklistBindings();
+  setupModeGrid();
+  setupEmailIntro();
+  setupTextAreas();
+  setupModeLists();
+  setupNavigation();
+  setupFoundationsOpens();
+  setupFinishButton();
+  buildPayloadHelpers();
+  drawProgress();
+  window.toast = toast;
+}
+
+on(document, 'DOMContentLoaded', init);
+
+// TODO: dividir el módulo en submódulos (HUD, rutas, envío) para seguir limpiando responsabilidades.

--- a/refactor/js/features/signupv2.js
+++ b/refactor/js/features/signupv2.js
@@ -1,0 +1,257 @@
+/**
+ * Módulo: SignupV2
+ * Propósito: mover la lógica de signupv2.html a un módulo claro y reutilizable.
+ * API pública: se auto-inicializa en DOMContentLoaded.
+ * Dependencias: utils/dom, utils/net.
+ * Side-effects: timers de polling, lectura de inputs y llamadas fetch/ImgBB.
+ * Comentario amigable: explicado como para un peque de 5 años 🙂.
+ */
+
+import {
+  byId,
+  on,
+  setHTML,
+  setText,
+  createElement,
+  serializeForm,
+} from '../utils/dom.js';
+import { fetchJsonWithRetry } from '../utils/net.js';
+
+const CONFIG = {
+  formAction: 'https://docs.google.com/forms/u/0/d/e/1FAIpQLSeXmBXfo0dw3srvcLzazcwW67K5Gv-dsvmdRDXVd78MRMjNLA/formResponse',
+  statusEndpoint: 'https://script.google.com/macros/s/AKfycbxOaMmRvEUweOyfXxj93ERX-ls8yvovoU5B_jjDg7qDeWLPhn70-0ClahMyOg69zJhf/exec',
+  formPublicUrl: 'https://rfullivarri.github.io/gamificationweblanding/formsintrov3.html',
+  loginUrl: 'loginv2.html',
+  pollInterval: 10000,
+  defaultAvatar: 'https://i.ibb.co/Mxf30SX5/Whats-App-Image-2025-07-29-at-10-17-40.jpg',
+  imgbbEndpoint: 'https://api.imgbb.com/1/upload?key=b78f6fa1f849b2c8fcc41ba4b195864f',
+};
+
+const state = {
+  lastEmail: '',
+  pollTimer: null,
+};
+
+const elements = {};
+
+function cacheElements() {
+  elements.form = byId('signup-form');
+  elements.avatarInput = byId('avatar');
+  elements.avatarPreview = byId('avatar-preview');
+  elements.filenamePreview = byId('filename-preview');
+  elements.status = byId('status');
+  elements.modal = byId('modal');
+  elements.modalTitle = byId('modalTitle');
+  elements.modalBody = byId('modalBody');
+  elements.modalActions = byId('modalActions');
+  elements.modalClose = byId('modalClose');
+}
+
+// ===== [Helpers sencillos] =====
+function setStatus(message, spinning = false) {
+  if (!elements.status) return;
+  const spinner = spinning ? ' <span class="spinner" aria-hidden="true"></span>' : '';
+  setHTML(elements.status, `${message}${spinner}`);
+}
+
+function showModal() {
+  if (!elements.modal) return;
+  elements.modal.classList.add('visible');
+  elements.modal.setAttribute('aria-hidden', 'false');
+}
+
+function hideModal() {
+  if (!elements.modal) return;
+  elements.modal.classList.remove('visible');
+  elements.modal.setAttribute('aria-hidden', 'true');
+}
+
+function drawModal(title, bodyHtml, actionConfigs) {
+  if (!elements.modalTitle || !elements.modalBody || !elements.modalActions) return;
+  setText(elements.modalTitle, title);
+  setHTML(elements.modalBody, bodyHtml);
+  setHTML(elements.modalActions, '');
+
+  actionConfigs.forEach((action) => {
+    const node = createElement(action.tag || 'button', {
+      className: action.className || 'btn',
+      innerHTML: action.html || action.text || 'OK',
+    });
+
+    if (action.href) {
+      node.setAttribute('href', action.href);
+      node.setAttribute('rel', 'noopener');
+      node.setAttribute('target', action.target || '_self');
+    }
+
+    if (typeof action.onClick === 'function') {
+      on(node, 'click', action.onClick);
+    }
+
+    elements.modalActions.appendChild(node);
+  });
+}
+
+function rememberEmail(email) {
+  state.lastEmail = email;
+}
+
+function startPolling() {
+  stopPolling();
+  state.pollTimer = window.setInterval(checkAndRenderStatus, CONFIG.pollInterval);
+}
+
+function stopPolling() {
+  if (state.pollTimer) {
+    window.clearInterval(state.pollTimer);
+    state.pollTimer = null;
+  }
+}
+
+async function checkAndRenderStatus() {
+  if (!state.lastEmail) return;
+  try {
+    const data = await fetchJsonWithRetry(
+      `${CONFIG.statusEndpoint}?email=${encodeURIComponent(state.lastEmail)}`,
+      { retries: 1, retryDelay: 1500, fetchOptions: { cache: 'no-store' } },
+    );
+
+    if (data?.ok && data?.processed) {
+      drawModal(
+        '¡Todo listo! 🎉',
+        '<p>Tu cuenta está activa. Ya podés entrar al Dashboard.</p>',
+        [
+          {
+            tag: 'a',
+            className: 'btn',
+            href: `${CONFIG.loginUrl}?email=${encodeURIComponent(state.lastEmail)}`,
+            text: 'Ir al Login',
+          },
+          { tag: 'a', className: 'btn ghost', href: 'indexv2.html', text: 'Volver al inicio' },
+        ],
+      );
+      stopPolling();
+      return;
+    }
+
+    drawModal(
+      'Falta un paso',
+      '<p>Completá el formulario para terminar la configuración. Apenas esté, te avisamos acá.</p>',
+      [
+        { tag: 'a', className: 'btn', href: CONFIG.formPublicUrl, target: '_blank', text: 'Completar formulario' },
+        { tag: 'a', className: 'btn ghost', href: 'indexv2.html', text: 'Más tarde' },
+      ],
+    );
+  } catch (_error) {
+    // Silenciar: volveremos a intentar en el próximo intervalo.
+  }
+}
+
+function showWaitingModal() {
+  showModal();
+  drawModal(
+    'Creando tu cuenta…',
+    '<p>Guardamos tus datos. Estamos preparando tu base con IA <span class="spinner"></span></p>',
+    [
+      { tag: 'a', className: 'btn ghost', href: 'indexv2.html', text: 'Más tarde' },
+      { tag: 'a', className: 'btn', href: CONFIG.formPublicUrl, target: '_blank', text: 'Completar formulario' },
+    ],
+  );
+}
+
+async function uploadAvatar(file) {
+  if (!file) return CONFIG.defaultAvatar;
+
+  const fileBase64 = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      const base64 = result.split(',')[1];
+      if (base64) resolve(base64);
+      else reject(new Error('avatar_read_error'));
+    };
+    reader.onerror = () => reject(new Error('avatar_read_error'));
+    reader.readAsDataURL(file);
+  });
+
+  try {
+    const response = await fetch(CONFIG.imgbbEndpoint, {
+      method: 'POST',
+      body: new URLSearchParams({ image: fileBase64 }),
+    });
+    const data = await response.json();
+    return data?.data?.url || CONFIG.defaultAvatar;
+  } catch (_error) {
+    return CONFIG.defaultAvatar;
+  }
+}
+
+async function submitForm(avatarUrl) {
+  const values = elements.form ? serializeForm(elements.form) : {};
+  const email = (values.email || '').trim().toLowerCase();
+  const nombre = (values.nombre || '').trim();
+  const apellido = (values.apellido || '').trim();
+  const edad = (values.edad || '').trim();
+  const sexo = (values.sexo || '').trim();
+
+  if (!email || !nombre) {
+    window.alert('Por favor, completá al menos tu email y nombre.');
+    return;
+  }
+
+  rememberEmail(email);
+
+  const formData = new FormData();
+  formData.append('entry.978262299', email);
+  formData.append('entry.268921631', nombre);
+  formData.append('entry.1084572637', apellido);
+  formData.append('entry.2109129788', edad);
+  formData.append('entry.1142848287', avatarUrl);
+  formData.append('entry.902905747', sexo);
+
+  try {
+    setStatus('Registrando…', true);
+    await fetch(CONFIG.formAction, { method: 'POST', mode: 'no-cors', body: formData });
+    showWaitingModal();
+    await checkAndRenderStatus();
+    startPolling();
+  } catch (error) {
+    window.alert('Ocurrió un error al registrar: ' + error);
+  }
+}
+
+async function handleSubmit(event) {
+  event.preventDefault();
+  const file = elements.avatarInput?.files?.[0];
+  const avatarUrl = await uploadAvatar(file);
+  submitForm(avatarUrl);
+}
+
+function handleAvatarPreview(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  const imageUrl = URL.createObjectURL(file);
+  if (elements.avatarPreview) elements.avatarPreview.src = imageUrl;
+  if (elements.filenamePreview) setText(elements.filenamePreview, file.name);
+}
+
+function bindEvents() {
+  if (elements.form) {
+    on(elements.form, 'submit', handleSubmit);
+  }
+  if (elements.avatarInput) {
+    on(elements.avatarInput, 'change', handleAvatarPreview);
+  }
+  if (elements.modalClose) {
+    on(elements.modalClose, 'click', hideModal);
+  }
+}
+
+function init() {
+  cacheElements();
+  bindEvents();
+}
+
+on(document, 'DOMContentLoaded', init);
+
+// TODO: mover a constantes compartidas los IDs entry.* si se reutilizan en otro flujo.

--- a/refactor/js/utils/dom.js
+++ b/refactor/js/utils/dom.js
@@ -83,6 +83,18 @@ export function setHTML(element, html) {
 }
 
 /**
+ * ===== [DOMUtils: setear texto plano] =====
+ * Cambia textContent y evita escapes manuales.
+ */
+export function setText(element, text) {
+  if (!element) {
+    console.error('[DOMUtils] No pude escribir texto porque el elemento es nulo');
+    return;
+  }
+  element.textContent = text;
+}
+
+/**
  * ===== [DOMUtils: mostrar/ocultar con hidden] =====
  * Usa el atributo hidden para no tocar clases ni estilos externos.
  */
@@ -105,4 +117,80 @@ export function focusFirstInteractive(scope) {
   if (focusables.length > 0) {
     focusables[0].focus();
   }
+}
+
+/**
+ * ===== [DOMUtils: crear elemento rápido] =====
+ * Genera nodos con clases, HTML interno y atributos opcionales.
+ */
+export function createElement(tagName, options = {}) {
+  const {
+    className,
+    innerHTML,
+    textContent,
+    attributes,
+    ...rest
+  } = options;
+  const element = document.createElement(tagName);
+  if (className) element.className = className;
+  if (typeof innerHTML === 'string') element.innerHTML = innerHTML;
+  if (typeof textContent === 'string') element.textContent = textContent;
+  if (attributes && typeof attributes === 'object') {
+    Object.entries(attributes).forEach(([key, value]) => {
+      element.setAttribute(key, value);
+    });
+  }
+  Object.entries(rest).forEach(([key, value]) => {
+    if (key.startsWith('data-')) {
+      element.setAttribute(key, value);
+      return;
+    }
+    if (key in element) {
+      element[key] = value;
+    }
+  });
+  return element;
+}
+
+/**
+ * ===== [DOMUtils: serializar formulario] =====
+ * Devuelve un objeto simple usando name o id como clave.
+ */
+export function serializeForm(form) {
+  if (!form) {
+    console.error('[DOMUtils] No pude serializar porque el formulario es nulo');
+    return {};
+  }
+  const result = {};
+  const elements = Array.from(form.elements || []);
+  elements.forEach((field) => {
+    if (!field || field.disabled) return;
+    const tag = (field.tagName || '').toLowerCase();
+    if (!tag) return;
+    const key = field.name || field.id;
+    if (!key) return;
+
+    if ((field.type === 'checkbox' || field.type === 'radio') && !field.checked) {
+      return;
+    }
+
+    let value;
+    if (tag === 'select' && field.multiple) {
+      value = Array.from(field.selectedOptions || []).map((opt) => opt.value);
+    } else if (field.type === 'file') {
+      value = field.files ? Array.from(field.files) : [];
+    } else {
+      value = field.value;
+    }
+
+    if (result[key] !== undefined) {
+      if (!Array.isArray(result[key])) {
+        result[key] = [result[key]];
+      }
+      result[key].push(value);
+    } else {
+      result[key] = value;
+    }
+  });
+  return result;
 }

--- a/refactor/views/formsintrov3.refactor.html
+++ b/refactor/views/formsintrov3.refactor.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Self-Improvement Journey</title>
+  <link rel="manifest" href="../../manifest.json">
+  <meta name="theme-color" content="#7d3cff">
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/base.css" />
+  <link rel="stylesheet" href="../css/formsintrov2.css" />
+</head>
+<body>
+
+  <!-- HUD fijo: marca, barras de XP y nombre interactivo -->
+  <header class="hud">
+    <div class="brand">
+      <span class="dot"></span>
+      <div class="journey">
+        <span id="hudTitle">Journey</span>
+        <div class="progress"><div id="progressFill" class="fill"></div></div>
+      </div>
+    </div>
+    <div class="mid">
+      <div class="pill">
+        <div class="row"><span class="emoji">🫀</span><span class="label">Body</span></div>
+        <progress id="barBody" value="0" max="100"></progress>
+      </div>
+      <div class="pill">
+        <div class="row"><span class="emoji">🧠</span><span class="label">Mind</span></div>
+        <progress id="barMind" value="0" max="100"></progress>
+      </div>
+      <div class="pill">
+        <div class="row"><span class="emoji">🏵️</span><span class="label">Soul</span></div>
+        <progress id="barSoul" value="0" max="100"></progress>
+      </div>
+    </div>
+    <div class="xp">XP: <span id="xpTotal">0</span></div>
+  </header>
+
+  <!-- Contenedor principal del wizard gamificado -->
+  <main class="overlay page">
+    <div class="modal">
+
+    <!-- Paso: Intro con campo de email obligatorio -->
+    <section class="scr active" id="scr-intro">
+      <div class="hero">
+        <div>
+          <h2>Cap. 0 — El Despertar</h2>
+          <p>Respirá. Hoy enciendes tu sistema de mejora. Te voy guiando para equilibrar <strong>Cuerpo, Mente y Alma</strong> con pasos simples.</p>
+          <p><strong>Cómo funciona:</strong> por cada pregunta que completes vas a ir sumando puntos de experiencia <strong>(XP)</strong>. Algunas valen <em>+21 XP</em> (respuestas escritas o clave de modo) y otras <em>+13 XP</em> (selecciones).</p>
+          <div class="field" style="margin:12px 0">
+            <label for="emailInput">Tu correo (obligatorio)</label>
+            <input
+              id="emailInput"
+              name="email"
+              type="email"
+              placeholder="tu@email.com"
+              autocomplete="email"
+              autocapitalize="none"
+              spellcheck="false"
+              inputmode="email"
+              enterkeyhint="go"
+              required
+            />
+            <small style="color:#aab7ff">Lo usamos para crear tu tablero y guardar tu progreso.</small>
+          </div>
+          <div class="nav">
+            <button class="btn secondary" id="backIntroDisabled" disabled>—</button>
+            <button class="btn" id="goModes" disabled>Comenzar</button>
+          </div>
+        </div>
+        <figure class="pic">
+          <img src="https://i.ibb.co/1GdbMQ1f/7e5cbb24-ebfe-4b0f-bbae-bddc1b66451a.jpg" alt="Intro">
+        </figure>
+      </div>
+    </section>
+
+    <!-- Paso: Selección de Game Mode -->
+    <section class="scr" id="scr-modes">
+      <div class="hero">
+        <div>
+          <h2>Elegí tu Game Mode</h2>
+          <p>Elegí el <strong>modo</strong> que mejor describe tu estado <strong>hoy</strong> para adaptar el recorrido a tu energía y enfoque.</p>
+          <div class="grid" id="modeGrid">
+            <div class="card" data-mode="LOW"><h3>🪫 LOW MOOD</h3><p class="note">Energía baja. Activamos tu mínimo vital con acciones pequeñas y seguras.</p></div>
+            <div class="card" data-mode="CHILL"><h3>🌿 CHILL MOOD</h3><p class="note">Tranquilo / estable. Sostener bienestar con rutinas suaves y balance.</p></div>
+            <div class="card" data-mode="FLOW"><h3>🌊 FLOW MOOD</h3><p class="note">Enfocado. Alineamos tu impulso con una meta clara sin descuidar el bienestar.</p></div>
+            <div class="card" data-mode="EVOLVE"><h3>🧬 EVOLVE MOOD</h3><p class="note">Ambición con propósito. Subimos de nivel con misiones y foco sostenible.</p></div>
+          </div>
+          <div class="nav">
+            <button class="btn secondary" id="backIntro">Volver</button>
+            <button class="btn" id="confirmMode" disabled>Confirmar modo</button>
+          </div>
+        </div>
+        <figure class="pic">
+          <img src="https://i.ibb.co/VcWFCZkL/b79005b1-97d9-4aa9-85dd-239861bb6c5c.jpg" alt="Modos">
+        </figure>
+      </div>
+    </section>
+
+    <!-- Paso LOW · Body: checklist guiada -->
+    <section class="scr" id="scr-low-body" data-type="checklist" data-pillar="Body" data-xp="13" data-limit="5">
+      <h2>LOW · 🫀 Body</h2>
+      <p>Elegí hasta <strong>5</strong> acciones simples que te harían bien ahora. <span class="xp-badge">+13 XP</span></p>
+      <div class="checklist" id="lowBodyList"></div>
+      <div class="counter"><span id="lowBodyCount">0</span>/5 seleccionadas (obligatorio)</div>
+
+      <div class="open-title">¿Hay algo que te cueste o quieras evitar a nivel físico? <span class="xp-badge">+21 XP</span></div>
+      <p class="note">Podés mencionar hábitos, dolores o ambientes que te incomodan… (opcional)</p>
+      <textarea id="fBodyOpen" rows="4" placeholder="Escribí si querés… (opcional)"></textarea>
+
+      <div class="nav">
+        <button class="btn secondary" id="backToModes1">Volver</button>
+        <button class="btn" id="confirmLowBody" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso LOW · Soul: checklist guiada -->
+    <section class="scr" id="scr-low-soul" data-type="checklist" data-pillar="Soul" data-xp="13" data-limit="5">
+      <h2>LOW · 🏵️ Soul</h2>
+      <p>Elegí hasta <strong>5</strong> cosas simples que te conectan con vos. <span class="xp-badge">+13 XP</span></p>
+      <div class="checklist" id="lowSoulList"></div>
+      <div class="counter"><span id="lowSoulCount">0</span>/5 seleccionadas (obligatorio)</div>
+
+      <div class="open-title">¿Qué tipo de prácticas espirituales te gustaría probar o retomar? <span class="xp-badge">+21 XP</span></div>
+      <p class="note">Podés incluir ejemplos personales… (opcional)</p>
+      <textarea id="fSoulOpen" rows="4" placeholder="Escribí si querés… (opcional)"></textarea>
+
+      <div class="nav">
+        <button class="btn secondary" id="backLowBody">Volver</button>
+        <button class="btn" id="confirmLowSoul" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso LOW · Mind: checklist guiada -->
+    <section class="scr" id="scr-low-mind" data-type="checklist" data-pillar="Mind" data-xp="13" data-limit="5">
+      <h2>LOW · 🧠 Mind</h2>
+      <p>Elegí hasta <strong>5</strong> acciones mentales que te ayuden hoy. <span class="xp-badge">+13 XP</span></p>
+      <div class="checklist" id="lowMindList"></div>
+      <div class="counter"><span id="lowMindCount">0</span>/5 seleccionadas (obligatorio)</div>
+
+      <div class="open-title">¿Qué te gustaría lograr con tu desarrollo mental? <span class="xp-badge">+21 XP</span></div>
+      <p class="note">Por ejemplo: leer más, organizar mejor el tiempo, mantenerte enfocado… (opcional)</p>
+      <textarea id="fMindOpen" rows="4" placeholder="Escribí si querés… (opcional)"></textarea>
+
+      <div class="nav">
+        <button class="btn secondary" id="backLowSoul">Volver</button>
+        <button class="btn" id="confirmLowMind" disabled>Confirmar</button>
+      </div>
+    </section>
+
+      <!-- Paso LOW · Nota final opcional -->
+    <section class="scr" id="scr-low-note" data-type="open" data-xp="21">
+      <h2>LOW · ¿Querés contarnos algo más?</h2>
+      <p class="note">Es opcional: solo una IA lo revisará. Podés dejarlo en blanco si no querés.</p>
+      <textarea id="lowNote" rows="4" placeholder="(opcional)"></textarea>
+      <div class="nav">
+        <button class="btn secondary" id="backLowMind">Volver</button>
+        <button class="btn" id="confirmLowNote">Continuar</button>
+      </div>
+    </section>
+
+    <!-- Paso CHILL · objetivo principal escrito -->
+    <section class="scr" id="scr-chill-open" data-type="open21">
+      <div class="hero">
+        <div>
+          <h2>CHILL · Una cosa este mes <span class="xp-badge">+21 XP</span></h2>
+          <p>Si pudieras mejorar o lograr <strong>solo una cosa</strong> este mes, ¿cuál sería?</p>
+          <textarea id="chillOneThing" rows="4" placeholder="Escribí tu respuesta… (obligatoria)"></textarea>
+          <div class="nav">
+            <button class="btn secondary" id="backToModes2">Volver</button>
+            <button class="btn" id="confirmChillOpen" disabled>Confirmar</button>
+          </div>
+        </div>
+        <figure class="pic"><img src="https://i.ibb.co/DDvczhR5/1e2bc15a-9f87-47b7-9b5b-c28156b69f0f.jpg" alt="Chill"></figure>
+      </div>
+    </section>
+
+    <!-- Paso CHILL · motivaciones clave -->
+    <section class="scr" id="scr-chill-motiv" data-type="mode13">
+      <h2>CHILL · ¿Qué te impulsa más? <span class="xp-badge">+13 XP</span></h2>
+      <p>Elegí las que sientas (al menos una).</p>
+      <div class="checklist" id="chillMotivList"></div>
+      <div class="nav">
+        <button class="btn secondary" id="backChillOpen">Volver</button>
+        <button class="btn" id="confirmChillMotiv" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso FLOW · objetivo principal -->
+    <section class="scr" id="scr-flow-goal" data-type="open21">
+      <div class="hero">
+        <div>
+          <h2>FLOW · Tu objetivo <span class="xp-badge">+21 XP</span></h2>
+          <p>¿Cuál es tu objetivo en este momento?</p>
+          <textarea id="flowGoal" rows="4" placeholder="Escribí tu objetivo… (obligatorio)"></textarea>
+          <div class="nav">
+            <button class="btn secondary" id="backToModes3">Volver</button>
+            <button class="btn" id="confirmFlowGoal" disabled>Confirmar</button>
+          </div>
+        </div>
+        <figure class="pic"><img src="https://i.ibb.co/DDvczhR5/1e2bc15a-9f87-47b7-9b5b-c28156b69f0f.jpg" alt="Flow"></figure>
+      </div>
+    </section>
+
+    <!-- Paso FLOW · obstáculos actuales -->
+    <section class="scr" id="scr-flow-imped" data-type="mode13">
+      <h2>FLOW · ¿Qué te lo viene impidiendo? <span class="xp-badge">+13 XP</span></h2>
+      <p>Elegí las que apliquen (al menos una).</p>
+      <div class="checklist" id="flowImpedList"></div>
+      <div class="nav">
+        <button class="btn secondary" id="backFlowGoal">Volver</button>
+        <button class="btn" id="confirmFlowImped" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso EVOLVE · objetivo desafiante -->
+    <section class="scr" id="scr-evolve-goal" data-type="open21">
+      <div class="hero">
+        <div>
+          <h2>EVOLVE · Objetivo desafiante <span class="xp-badge">+21 XP</span></h2>
+          <p>¿Cuál es tu objetivo desafiante?</p>
+          <textarea id="evolveGoal" rows="4" placeholder="Escribí tu objetivo… (obligatorio)"></textarea>
+          <div class="nav">
+            <button class="btn secondary" id="backToModes4">Volver</button>
+            <button class="btn" id="confirmEvolveGoal" disabled>Confirmar</button>
+          </div>
+        </div>
+        <figure class="pic"><img src="https://i.ibb.co/DDvczhR5/1e2bc15a-9f87-47b7-9b5b-c28156b69f0f.jpg" alt="Evolve"></figure>
+      </div>
+    </section>
+
+    <!-- Paso EVOLVE · ajustes posibles -->
+    <section class="scr" id="scr-evolve-trade" data-type="mode13">
+      <h2>EVOLVE · ¿Qué estás dispuesto a ajustar? <span class="xp-badge">+13 XP</span></h2>
+      <p>Elegí las que apliquen (al menos una).</p>
+      <div class="checklist" id="evolveTradeList"></div>
+      <div class="nav">
+        <button class="btn secondary" id="backEvolveGoal">Volver</button>
+        <button class="btn" id="confirmEvolveTrade" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso EVOLVE · actitud ante el cambio -->
+    <section class="scr" id="scr-evolve-att" data-type="mode21-radio">
+      <h2>EVOLVE · Actitud ante el cambio <span class="xp-badge">+21 XP</span></h2>
+      <p>Elegí una opción.</p>
+      <div class="checklist" id="evolveAttList"></div>
+      <div class="nav">
+        <button class="btn secondary" id="backEvolveTrade">Volver</button>
+        <button class="btn" id="confirmEvolveAtt" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso Foundations · Body -->
+    <section class="scr" id="scr-f-body" data-type="checklist" data-pillar="Body" data-xp="13" data-limit="5">
+      <h2>Foundations · 🫀 Body</h2>
+      <p>Lo físico es tu base. Elegí hasta <strong>5</strong> anclas. <span class="xp-badge">+13 XP</span></p>
+      <div class="checklist" id="fBodyList"></div>
+      <div class="counter"><span id="fBodyCount">0</span>/5 seleccionadas (obligatorio)</div>
+
+      <div class="open-title">¿Hay algo que te cueste o quieras evitar a nivel físico? <span class="xp-badge">+21 XP</span></div>
+      <p class="note">Podés mencionar hábitos, dolores o ambientes que te incomodan… (opcional)</p>
+      <textarea id="fBodyOpen2" rows="4" placeholder="Escribí si querés… (opcional)"></textarea>
+
+      <div class="nav">
+        <button class="btn secondary" id="backFoundPrev1">Volver</button>
+        <button class="btn" id="confirmFBody" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso Foundations · Soul -->
+    <section class="scr" id="scr-f-soul" data-type="checklist" data-pillar="Soul" data-xp="13" data-limit="5">
+      <h2>Foundations · 🏵️ Soul</h2>
+      <p>Sin centro, no hay llegada. Elegí hasta <strong>5</strong> prácticas. <span class="xp-badge">+13 XP</span></p>
+      <div class="checklist" id="fSoulList"></div>
+      <div class="counter"><span id="fSoulCount">0</span>/5 seleccionadas (obligatorio)</div>
+
+      <div class="open-title">¿Qué tipo de prácticas espirituales te gustaría probar o retomar? <span class="xp-badge">+21 XP</span></div>
+      <p class="note">Podés incluir ejemplos personales… (opcional)</p>
+      <textarea id="fSoulOpen2" rows="4" placeholder="Escribí si querés… (opcional)"></textarea>
+
+      <div class="nav">
+        <button class="btn secondary" id="backFBody">Volver</button>
+        <button class="btn" id="confirmFSoul" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso Foundations · Mind -->
+    <section class="scr" id="scr-f-mind" data-type="checklist" data-pillar="Mind" data-xp="13" data-limit="5">
+      <h2>Foundations · 🧠 Mind</h2>
+      <p>No es hacer más: es <strong>hacer mejor</strong>. Elegí hasta <strong>5</strong> focos. <span class="xp-badge">+13 XP</span></p>
+      <div class="checklist" id="fMindList"></div>
+      <div class="counter"><span id="fMindCount">0</span>/5 seleccionadas (obligatorio)</div>
+
+      <div class="open-title">¿Qué te gustaría lograr con tu desarrollo mental? <span class="xp-badge">+21 XP</span></div>
+      <p class="note">Por ejemplo: leer más, organizar mejor el tiempo, mantenerte enfocado… (opcional)</p>
+      <textarea id="fMindOpen2" rows="4" placeholder="Escribí si querés… (opcional)"></textarea>
+
+      <div class="nav">
+        <button class="btn secondary" id="backFSoul">Volver</button>
+        <button class="btn" id="confirmFMind" disabled>Confirmar</button>
+      </div>
+    </section>
+
+    <!-- Paso final: resumen y CTA -->
+    <section class="scr" id="scr-summary">
+      <h2>¡Todo listo para empezar! 🚀</h2>
+      <div class="summary-box" id="summaryBox"></div>
+      <p class="note" style="margin-top:10px">
+        <strong>Capitán</strong>, con esto generamos tus <strong>primeras tasks</strong> y un plan simple para hoy.
+        Vas a poder ver tu avance y reacomodar prioridades en tu <strong>tablero personal</strong>, pero lo importante es el <em>ritmo</em>:
+        pasos cortos, XP real, progreso visible.
+      </p>
+      <div class="nav">
+        <button class="btn secondary" id="restart">Volver al inicio</button>
+        <button class="btn" id="finish">Comenzar Journey</button>
+      </div>
+    </section>
+
+    <!-- Toasts fijos para sumar XP visualmente -->
+    <div id="toast13" class="toast">+13 XP</div>
+    <div id="toast21" class="toast">+21 XP</div>
+
+  </div> <!-- cierra .modal -->
+  </main>
+  <!-- Toast flotante reutilizado para mensajes rápidos -->
+  <div id="toast" class="toast"></div>
+
+  <!-- Hook JS: lógica del wizard y envío final -->
+  <script type="module" src="../js/features/formsintrov2.js"></script>
+</body>
+</html>

--- a/refactor/views/signupv2.refactor.html
+++ b/refactor/views/signupv2.refactor.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Crear cuenta — Gamification Journey</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="../../manifest.json">
+  <meta name="theme-color" content="#7d3cff">
+  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/base.css" />
+  <link rel="stylesheet" href="../css/signupv2.css" />
+</head>
+<body class="signupv2">
+  <!-- Barra superior: marca y acceso al login -->
+  <header class="nav">
+    <a class="brand" href="indexv2.html">Gamification Journey</a>
+    <nav class="nav-actions">
+      <a class="btn ghost" href="loginv2.html">Ya tengo cuenta</a>
+    </nav>
+  </header>
+
+  <!-- Tarjeta central con el formulario de alta -->
+  <main class="wrap">
+    <section class="card">
+      <h1>Crear mi cuenta</h1>
+      <p class="sub">En menos de 3 minutos generamos tu base personalizada con IA.</p>
+
+      <!-- Formulario: mantiene IDs y estructura original -->
+      <form id="signup-form" novalidate>
+        <!-- Campos principales agrupados en grilla -->
+        <div class="grid">
+          <div class="field">
+            <label for="email">Correo</label>
+            <input id="email" type="email" placeholder="heroe@reino.com" required />
+          </div>
+          <div class="field">
+            <label for="nombre">Nombre</label>
+            <input id="nombre" type="text" placeholder="Tu nombre de aventurero" required />
+          </div>
+          <div class="field">
+            <label for="apellido">Apellido</label>
+            <input id="apellido" type="text" placeholder="Tu legado" />
+          </div>
+          <div class="field">
+            <label for="edad">Edad</label>
+            <input id="edad" type="number" placeholder="18" />
+          </div>
+          <div class="field">
+            <label for="sexo">Sexo</label>
+            <select id="sexo">
+              <option value="">Seleccionar</option>
+              <option>Masculino</option>
+              <option>Femenino</option>
+              <option>Prefiero no decirlo</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Bloque avatar: imagen, carga y vista previa del nombre del archivo -->
+        <div class="avatar-block">
+          <img id="avatar-preview" src="https://i.ibb.co/Mxf30SX5/Whats-App-Image-2025-07-29-at-10-17-40.jpg" alt="Avatar preview" />
+          <label class="btn secondary file-label">
+            Subir avatar
+            <input type="file" id="avatar" accept="image/*" hidden />
+          </label>
+          <div id="filename-preview" class="tiny"></div>
+        </div>
+
+        <!-- Acciones y estado en vivo -->
+        <div class="actions">
+          <button type="submit" class="btn" id="createBtn">Crear cuenta</button>
+          <a class="btn ghost" href="indexv2.html">Volver al inicio</a>
+        </div>
+        <div id="status" class="status"></div>
+      </form>
+    </section>
+  </main>
+
+  <!-- Modal accesible para mostrar progreso y próximos pasos -->
+  <section id="modal" class="modal" aria-hidden="true">
+    <div class="modal-card">
+      <button id="modalClose" class="close">✕</button>
+      <h2 id="modalTitle" class="modal-title">Procesando…</h2>
+      <div id="modalBody" class="modal-body">
+        <p>Estamos creando tu cuenta <span class="spinner"></span></p>
+      </div>
+      <div id="modalActions" class="modal-actions">
+        <!-- Se completan dinámicamente según el estado -->
+      </div>
+    </div>
+  </section>
+
+  <!-- Script principal refactorizado -->
+  <script type="module" src="../js/features/signupv2.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add refactored signup and onboarding HTML views that reference new CSS and module scripts with clear inline documentation
- extract page-specific styles into `refactor/css/signupv2.css` and `refactor/css/formsintrov2.css` to preserve the original look & feel
- move inline logic into `refactor/js/features/signupv2.js` and `refactor/js/features/formsintrov2.js`, extending DOM/net utils to support reusable helpers

## Testing
- not run (static HTML/JS refactor)


------
https://chatgpt.com/codex/tasks/task_e_68de9a3254c08322bf3af5985a522a41