### PR TITLE
Refactor BBDD editor into modular assets

### DIFF
--- a/refactor/DOCUMENTATION.refactor.md
+++ b/refactor/DOCUMENTATION.refactor.md
@@ -5,6 +5,8 @@
 ## Vistas
 - `views/indexv2.refactor.html` — Landing principal. Usa `css/stylesv3.css` para visuales y `js/features/landing.js` para el carrusel accesible.
 - `views/loginv2.refactor.html` — Portal de acceso. Usa `css/layout.css` y el módulo `js/features/login.js`.
+- `views/index-bbdd.refactor.html` — Editor BBDD compacto con overlay. Depende de `css/bbdd.css` y `js/features/bbdd.js`.
+- `views/offline.refactor.html` — Pantalla offline reducida que comparte paleta con la vista BBDD.
 
 ## Utilidades JS
 - `js/utils/dom.js` — Selectores seguros, escucha de eventos y helpers para manipular atributos sin repetir código.
@@ -17,6 +19,10 @@
 2. Verificá que los enlaces sigan apuntando a las rutas originales (`signupv2.html`, `dashboardv3.html`, etc.).
 3. Revisá la consola: no debe haber errores nuevos. Si aparece alguno, anotarlo en TODO.
 4. Compará visualmente con la versión original para asegurar que la UI/UX no cambió.
+
+### Manifest + Service Worker refactor
+- `manifest.refactor.json` replica el manifiesto sin tocar `manifest.json`. Para probarlo, cargá la vista refactor desde un servidor local y, en DevTools → Application → Manifest, usá “Update on reload” y forzá el campo `Start URL` a `refactor/views/index-bbdd.refactor.html`.
+- `sw.refactor.js` se registra automáticamente al cargar `index-bbdd.refactor.html` gracias al módulo `js/features/bbdd.js`. Si querés probar otra variante, desregistrá con `navigator.serviceWorker.getRegistration()?.unregister()` y volvé a registrar manualmente con `navigator.serviceWorker.register('/refactor/sw.refactor.js', { scope: '/' })`.
 
 ## Convenciones
 - Comentarios con tono sencillo, como si se lo explicáramos a alguien de 5 años.

--- a/refactor/css/bbdd.css
+++ b/refactor/css/bbdd.css
@@ -1,0 +1,921 @@
+/* =========================================================================
+   Componente: BBDD
+   Uso: replica la vista de edición compacta de tareas con overlay flotante.
+   Notas: tokens base reutilizados; los bloques siguen el orden original del inline.
+   ========================================================================== */
+
+:root{
+      --bg:var(--color-bg-dark, #0b0f19);
+      --ink:var(--color-text-main, #e9eef7);
+      --muted:var(--color-text-muted, #9aa3b2);
+      --accent:#7d3cff; --accent2:#9a74ff;
+      --card:#101726; --chip:#17203a; --border:#1d2743; --shadow:0 12px 28px rgba(0,0,0,.35);
+      --tap:44px; --r:14px; --actionsw:180px;
+    }
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{height:100%;}
+    body{
+      margin:0;
+      background:linear-gradient(180deg,var(--bg) 0%,#0d1324 100%);
+      color:var(--ink);
+      font:15px/1.4 "Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      -webkit-font-smoothing:antialiased;
+    }
+
+    a{color:inherit}
+    button,input,select{font:inherit}
+    select,button{cursor:pointer}
+
+    .hidden{display:none !important}
+
+    /* Overlay */
+    #bbdd-overlay{
+      position:fixed; inset:0; z-index:80;
+      background:rgba(4,6,12,.6);
+      backdrop-filter:blur(18px) saturate(120%);
+      -webkit-backdrop-filter:blur(18px) saturate(120%);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:clamp(5px,1vh,10px);   /* MODIFIQUE */
+      overflow-y:auto;
+    }
+    .bbdd-panel{
+      width:min(960px,100%);
+      height:min(100dvh,960px);
+      max-height:100dvh;
+      background:rgba(16,23,38,.86);
+      border:1px solid rgba(125,60,255,.25);
+      border-radius:18px;
+      display:flex;
+      flex-direction:column;
+      overflow:hidden;
+      position:relative;
+      box-shadow:0 18px 44px rgba(0,0,0,.45);
+    }
+
+    header.appbar{
+      position:sticky;
+      top:0;
+      z-index:20;
+      padding:14px clamp(14px,4vw,26px) 10px;
+      background:linear-gradient(180deg,rgba(14,20,35,.98),rgba(14,20,35,.82));
+      border-bottom:1px solid rgba(125,60,255,.22);
+    }
+    header.appbar .top-row{display:flex;flex-wrap:wrap;gap:12px;margin-bottom:8px;align-items:center;}
+    header.appbar .top-row .primary{display:flex;align-items:center;gap:12px;flex:1 1 320px;min-width:0;flex-wrap:wrap;}
+    header.appbar .top-row .primary .btn.icon{flex-shrink:0;}
+    header.appbar .title-wrap{flex:1 1 220px;min-width:0;}
+    header.appbar .title{font-weight:800;font-size:1.06rem;line-height:1.25;}
+    header.appbar .sub{font-size:.78rem;color:var(--muted);margin-top:2px;}
+    header.appbar .row-actions{display:flex;align-items:center;gap:8px;margin-left:auto;flex-wrap:wrap;min-width:0;flex:0 0 auto;}
+    header.appbar .row-actions .btn{white-space:nowrap;flex:0 0 auto;}
+
+    .btn{
+      appearance:none;
+      border:1px solid rgba(125,60,255,.25);
+      background:var(--chip);
+      color:var(--ink);
+      min-height:var(--tap);
+      border-radius:12px;
+      padding:10px 14px;
+      font-weight:600;
+      transition:background .2s,border-color .2s,transform .2s;
+    }
+    .btn:hover{border-color:var(--accent2);background:rgba(125,60,255,.16);}
+    .btn.icon{width:var(--tap);display:grid;place-items:center;padding:0;font-size:18px;}
+    .btn.primary{background:linear-gradient(135deg,var(--accent),var(--accent2));border:none;box-shadow:0 10px 30px rgba(125,60,255,.35);}
+    .btn.primary[disabled]{opacity:.55;cursor:progress;box-shadow:none;}
+
+    details.guide{
+      margin:12px 0;
+      border:1px solid rgba(157,167,200,.25);
+      border-radius:14px;
+      background:rgba(18,27,46,.88);
+      padding:10px 14px;
+      box-shadow:0 12px 28px rgba(0,0,0,.3);
+    }
+    details.guide summary{cursor:pointer;color:#cfd6f8;font-weight:600;}
+    details.guide ul{margin:10px 0 0 18px;color:var(--muted);padding:0 0 4px 0;}
+
+    .tools{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin:10px 0 2px;}
+    .field{flex:1 1 220px;display:flex;align-items:center;gap:8px;background:rgba(18,26,44,.92);border:1px solid rgba(125,60,255,.16);border-radius:12px;padding:0 12px;min-height:42px;min-width:0;}
+    .field input{flex:1;min-width:0;background:transparent;border:0;outline:0;color:var(--ink);font-size:15px;}
+    .left-tools{display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+    .indicator{font-size:.78rem;color:#ffd166;display:flex;align-items:center;gap:6px;}
+    .indicator.hidden{display:none!important;}
+
+    #bbdd-ai{position:relative;}
+    #ai-sparkle{position:absolute;inset:-6px;pointer-events:none;background:radial-gradient(circle at top,var(--accent2),transparent 60%);opacity:0;animation:pulse 1.6s infinite;}
+    .ai-loading #ai-sparkle{opacity:1;}
+    @keyframes pulse{0%,100%{opacity:.1;}50%{opacity:.45;}}
+
+    main{
+      flex:1;
+      overflow:auto;
+      padding:0 clamp(12px,4vw,28px) clamp(96px,12vh,150px);
+      position:relative;
+      scroll-behavior:smooth;
+    }
+
+    .thead{display:flex;align-items:center;justify-content:space-between;color:var(--muted);font-size:.78rem;margin:6px 2px 0;gap:8px;}
+    .thead .label{flex:1 1 auto;min-width:0;}
+    .thead .add{min-height:36px;padding:0 12px;border-radius:10px;background:rgba(125,60,255,.16);border-color:rgba(125,60,255,.4);}
+
+    #table-wrap{position:relative;}
+    #bbdd-table{width:100%;border-collapse:collapse;}
+    #bbdd-table colgroup,#bbdd-table thead{display:none;}
+    #bbdd-table tbody tr{display:table-row;}
+    #bbdd-table td{border:0;padding:0;background:transparent;}
+
+    .item{position:relative;margin:6px 0;height:auto;border-radius:16px;overflow:hidden;touch-action:pan-y;}
+    .item .actions{position:absolute;inset:0;display:flex;align-items:center;justify-content:flex-end;gap:6px;padding-right:10px;min-width:var(--actionsw);background:linear-gradient(90deg,transparent 32%,rgba(10,14,28,.88) 100%);}
+    .item .act{width:46px;height:46px;border-radius:50%;border:1px solid rgba(125,60,255,.35);background:rgba(32,38,66,.88);color:#fff;font-size:1.24rem;font-weight:700;display:flex;align-items:center;justify-content:center;box-shadow:0 6px 18px rgba(0,0,0,.32);}
+    .item .act.modify{border-color:#2b8fdb;background:rgba(26,48,78,.88);}
+    .item .act.improve{border-color:#8c5cff;background:rgba(39,28,78,.9);}
+    .item .act.del{border-color:#e74c3c;background:rgba(64,20,28,.92);}
+
+    .slidable{position:relative;display:flex;align-items:flex-start;gap:10px;background:var(--card);border:1px solid rgba(125,60,255,.22);border-radius:16px;padding:12px 14px;transition:transform .18s ease;will-change:transform;box-shadow:var(--shadow);}
+    .slidable .mark{width:6px;border-radius:999px;background:linear-gradient(180deg,#2a7fff,#7d3cff);align-self:stretch;}
+    .slidable .content{flex:1;min-width:0;display:flex;flex-direction:column;gap:10px;}
+    .row-main{display:flex;align-items:center;gap:10px;}
+    .task-input{flex:1;min-width:0;background:rgba(255,255,255,.02);border:1px solid rgba(125,60,255,.24);border-radius:12px;padding:10px 12px;color:var(--ink);}
+    .task-input.ai-updated{border-color:#71e6b5;box-shadow:0 0 0 1px rgba(113,230,181,.35);}
+    .task-input::placeholder{color:rgba(233,238,247,.35);}
+
+    .meta{display:grid;gap:10px;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));background:rgba(255,255,255,.02);border:1px solid rgba(125,60,255,.18);border-radius:12px;padding:10px;opacity:0;max-height:0;overflow:hidden;transition:opacity .18s ease,max-height .18s ease;}
+    .item.expanded .meta{opacity:1;max-height:460px;}
+    .meta label{display:flex;flex-direction:column;font-size:.74rem;color:var(--muted);gap:6px;}
+    .meta select,.meta input{width:100%;background:rgba(14,24,40,.9);border:1px solid rgba(125,60,255,.22);border-radius:10px;min-height:36px;padding:6px 10px;color:var(--ink);}
+    .meta input::placeholder{color:rgba(233,238,247,.3);}
+    .meta .feedback{display:flex;gap:8px;align-items:center;justify-content:flex-start;grid-column:1 / -1;}
+    .meta .feedback button{width:40px;height:40px;border-radius:10px;border:1px solid rgba(125,60,255,.28);background:rgba(24,32,52,.9);color:var(--ink);font-size:1.1rem;display:flex;align-items:center;justify-content:center;}
+    .item:not(.expanded) .meta .feedback{display:none;}
+    .meta-actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center;grid-column:1 / -1;}
+    .meta-actions .meta-btn{flex:1 1 120px;min-height:36px;border-radius:10px;border:1px solid rgba(125,60,255,.22);background:rgba(18,28,48,.88);color:var(--ink);font-weight:600;font-size:.82rem;padding:6px 10px;display:flex;align-items:center;gap:8px;justify-content:center;}
+    .meta-actions .meta-btn.danger{border-color:#e74c3c;color:#ffb1b8;background:rgba(56,20,32,.92);}
+
+    .diff-chip,.more{
+      height:40px;
+      width:42px;
+      border-radius:11px;
+      border:1px solid rgba(125,60,255,.22);
+      background:rgba(22,30,50,.92);
+      color:var(--ink);
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:0 10px;
+    }
+    .diff-chip{width:auto;gap:8px;padding:0 14px;font-weight:600;font-size:.86rem;}
+    .diff-chip .dot{width:10px;height:10px;border-radius:99px;background:#8a93a7;}
+    .diff-chip[data-v="Fácil"] .dot{background:#2ecc71;}
+    .diff-chip[data-v="Media"] .dot{background:#f1c40f;}
+    .diff-chip[data-v="Difícil"] .dot{background:#e74c3c;}
+
+    .more{font-size:20px;}
+    .item.expanded .more{background:rgba(125,60,255,.2);border-color:rgba(125,60,255,.5);}
+
+    .item.swipe-hint .slidable{animation:swipe-hint 2.6s ease-in-out infinite;}
+
+    @keyframes swipe-hint{
+      0%,60%,100%{transform:translateX(0);}
+      25%{transform:translateX(calc(-1 * var(--actionsw) * .55));}
+      45%{transform:translateX(0);}
+    }
+
+    .item.ai-improved .slidable{border-color:rgba(140,92,255,.65);box-shadow:0 0 0 1px rgba(140,92,255,.35),0 14px 34px rgba(83,57,168,.35);}
+    .item.ai-modified .slidable{border-color:rgba(113,230,181,.8);box-shadow:0 0 0 1px rgba(113,230,181,.35),0 14px 34px rgba(36,126,104,.3);}
+
+    .bbdd-footer{
+      position:absolute;
+      inset:auto 0 0 0;
+      padding:14px clamp(14px,4vw,24px) calc(env(safe-area-inset-bottom)+18px);
+      background:linear-gradient(180deg,rgba(11,16,28,.1) 0%,rgba(11,16,28,.88) 45%,rgba(11,16,28,.98) 100%);
+      display:flex;
+      align-items:center;
+      gap:10px;
+    }
+    #status-msg{flex:1;color:#9ff7cc;font-size:.82rem;transition:opacity .2s;}
+    .bbdd-footer .btn{min-height:42px;}
+
+    #table-spinner{
+      position:fixed;
+      inset:0;
+      display:none;
+      align-items:center;
+      justify-content:center;
+      flex-direction:column;
+      gap:12px;
+      background:rgba(8,12,24,.82);
+      color:var(--ink);
+      font-weight:600;
+      z-index:120;
+      pointer-events:auto;
+    }
+    #table-wrap.table-loading #table-spinner{display:flex;}
+    #table-spinner .ring{
+      width:36px;height:36px;border-radius:50%;
+      border:3px solid rgba(125,60,255,.18);
+      border-top-color:var(--accent2);
+      animation:spin .9s linear infinite;
+    }
+    #ai-overlay{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(7,12,26,.82);color:#cfd7ff;font-weight:600;z-index:130;gap:10px;}
+    #ai-overlay .spark{font-size:1.4rem;animation:twinkle 1.6s ease-in-out infinite;}
+    .ai-loading #ai-overlay{display:flex;}
+    @keyframes twinkle{0%,100%{opacity:.4;transform:scale(1);}50%{opacity:1;transform:scale(1.2);}}
+    @keyframes spin{to{transform:rotate(360deg);}}
+
+    #add-row-dup{display:none;align-items:center;justify-content:center;padding:0 12px;}
+
+    /* Responsive */
+    @media (min-width:780px){
+      body{background:#060912;}
+      header.appbar{padding:18px 40px 14px;}
+      main{padding:10px 40px 180px;}
+      .item{margin:12px 0;}
+      .slidable{gap:16px;padding:18px;}
+      .meta{grid-template-columns:repeat(3,minmax(160px,1fr));}
+    }
+
+    @media (max-width:720px){
+      header.appbar .top-row{align-items:flex-start;}
+      header.appbar .top-row .primary{width:100%;align-items:flex-start;}
+      header.appbar .top-row .primary .title-wrap{flex-basis:100%;}
+      header.appbar .top-row .row-actions{width:100%;margin-left:0;justify-content:flex-end;}
+      header.appbar .top-row .row-actions .btn{flex:1;min-width:0;}
+      .tools{flex-direction:column;align-items:stretch;gap:8px;}
+      .left-tools{width:100%;justify-content:flex-start;}
+      .field{width:100%;}
+      #bbdd-ai{width:100%;}
+      #add-row{display:none;}
+      #add-row-dup{display:inline-flex;}
+      .meta{grid-template-columns:repeat(auto-fit,minmax(120px,1fr));}
+    }
+
+    @media (max-width:520px){
+      .slidable{padding:12px 12px 14px;}
+      .task-input{font-size:.94rem;}
+      .btn.primary{min-width:160px;}
+      .meta-actions .meta-btn{flex:1 1 100%;}
+    }
+
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0;}
+    /* === Glow verde al enfocar === */
+    .slidable:has(.task-input:focus){
+      border-color:#71e6b5;
+      box-shadow:0 0 0 1px rgba(113,230,181,.45), 0 14px 34px rgba(36,126,104,.28);
+    }
+    .task-input:focus{
+      outline:0;
+      border-color:#71e6b5;
+      box-shadow:0 0 0 2px rgba(113,230,181,.30);
+    }
+    
+    /* === Tarjeta compacta + grid con barrita === */
+    .item{ margin:6px 0; }
+    
+    .slidable{
+      display:grid;
+      grid-template-columns: var(--mark-w,6px) 1fr auto auto; /* barrita | texto | chip | ... */
+      align-items:center;
+      column-gap:7px;
+      padding:5px 7px;
+    }
+    
+    /* Barrita izquierda */
+    .slidable .mark{
+      grid-column:1;
+      align-self:stretch;
+      width:var(--mark-w,6px);
+      border-radius:999px;
+      background:linear-gradient(180deg,#2a7fff,#7d3cff);
+    }
+    
+    /* Contenido de texto (se expande a tope) */
+    .slidable .content{
+      grid-column:2;
+      min-width:0;
+    }
+    .row-main{
+      display:flex;
+      align-items:center;
+      gap:8px;
+      min-width:0;
+    }
+    .task-input{
+      flex:1 1 auto;
+      min-width:0;
+      width:100%;
+      padding:8px 10px;
+      border-radius:10px;
+    }
+    
+    /* Controles a la derecha */
+    .slidable .diff-chip{
+      grid-column:3;
+      white-space:nowrap;
+      padding:0 5px;
+    }
+    .slidable .more{
+      grid-column:4;
+      width:44px;
+      min-width:44px;
+    }
+    .diff-chip, .more{ height:34px; }
+    
+    /* Meta (bloque expandible) más denso */
+    .meta{ padding:8px; gap:8px; }
+    
+    /* === Responsive === */
+    @media (max-width:480px){
+      .slidable{ column-gap:8px; }
+      .slidable .diff-chip{ padding:0 8px; }
+      .slidable .more{ width:40px; min-width:40px; }
+      .task-input{ padding:6px 8px; }
+    }
+    @media (max-width:380px){
+      .slidable{ column-gap:6px; }
+      .slidable .diff-chip{ padding:0 6px; font-size:.92rem; }
+      .slidable .more{ width:36px; min-width:36px; }
+    }
+
+    /* Header pegado arriba que se mueve suavemente con el scroll */
+    header.appbar{
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      will-change: transform;
+      /* sin clase .hidden, la animación la controla JS */
+    }
+    
+    /* (opcional) transición cuando soltás el scroll y “encaja” en visible/oculto */
+    header.appbar.is-snapping{
+      transition: transform .18s ease;
+    }
+
+    /* --- Panel: único contenedor con scroll --- */
+    .bbdd-panel{
+      height: 100dvh;
+      overflow: auto;              /* ahora el panel scrollea */
+      display: flex;
+      flex-direction: column;
+    }
+    
+    /* main ya no scrollea */
+    .bbdd-panel > main{
+      flex: 1 1 auto;
+      overflow: visible;
+    }
+    
+    /* Appbar sticky dentro del panel + transición suave por transform */
+    header.appbar{
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      transform: translateY(var(--appbarShift, 0px));
+      transition: transform .12s linear; /* micro-suavizado cuando se frena */
+    }
+    
+    /* Botón Confirmar SIEMPRE visible (flotante) */
+    #bbdd-confirm{
+      position: fixed;                         /* flota dentro de la ventana */
+      right: clamp(12px, 3vw, 28px);
+      top: calc(12px + env(safe-area-inset-top, 0px));
+      z-index: 60;
+      box-shadow: 0 14px 34px rgba(125,60,255,.35);
+    }
+    
+    /* Un poco de margen arriba del contenido para que no quede tapado
+       por el botón flotante en pantallas chicas */
+    @media (max-width: 520px){
+      .bbdd-panel > main{ padding-top: 56px; }
+    }
+    
+    /* (Opcional) compactito para que entren más tarjetas en pantalla */
+    .item{ margin:6px 0; }
+    .slidable{ padding:10px 12px; }
+
+    /* El panel es un único scroller con header sticky y footer sticky */
+    .bbdd-panel{
+      display:flex;
+      flex-direction:column;
+      height:100dvh;              /* ocupa todo el alto del viewport */
+    }
+    
+    /* El panel es EL ÚNICO scroller */
+    .bbdd-panel{
+      height: 100dvh;
+      overflow: auto;
+    }
+    
+    /* main no scrollea */
+    .bbdd-panel main{
+      overflow: visible;            /* <- importantísimo */
+      padding-top: var(--appbar-pad, 0px); /* se ajusta desde JS */
+    }
+    
+    /* Appbar sticky que se oculta suavemente por transform */
+    header.appbar{
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      transform: translateY(var(--appbarShift, 0));
+      transition: transform .16s ease;    /* suavidad */
+    }
+    
+    /* Footer siempre visible dentro del panel */
+    .bbdd-footer{
+      position: sticky;
+      bottom: 0;
+      z-index: 15;
+    }
+
+    /* === Un solo scroller === */
+    .bbdd-panel{
+      height:100dvh;
+      overflow:auto;
+      display:flex;
+      flex-direction:column;
+    }
+    
+    /* Header sticky que se oculta con transform */
+    header.appbar{
+      position:sticky;
+      top:0;
+      z-index:20;
+      transform: translateY(calc(-1 * var(--appbarHide, 0px)));
+      transition: transform .12s linear; /* suave cuando se frena */
+      will-change: transform;
+    }
+    
+    /* El contenido arranca justo debajo del header visible:
+       padding-top = altoHeader - loOcultado */
+    .bbdd-panel > main{
+      flex:1 1 auto;
+      overflow:visible;
+      padding-top: 0 !important; 
+    }
+    
+    /* Footer pegado abajo siempre visible */
+    .bbdd-footer{
+      position:sticky;
+      bottom:0;
+      z-index:15;
+    }
+    
+    /* Botón Confirmar flotante (si lo querés siempre visible) */
+    #bbdd-confirm{
+      position:fixed;
+      right:clamp(12px,3vw,28px);
+      top:calc(12px + env(safe-area-inset-top,0px));
+      z-index:60;
+    }
+    
+    /* (Opcional) tarjetas un poco más compactas */
+    .item{ margin:6px 0; }
+    .slidable{ padding:10px 12px; }
+
+
+
+    /***************** PARCHE VISUAL – copiar al final *****************/
+
+    /* 1) Ocultar el botón AI (Beta) de la barra de herramientas */
+    #bbdd-ai{ display:none !important; }
+    
+    /* 2) Confirmar: flotante, sin tapar la flecha, alineado y con ancho razonable */
+    header.appbar { position: sticky; top: 0; z-index: 30; }
+    header.appbar .row-actions { position: relative; }
+    
+    /* Botón fijo en la ventana pero con límites de tamaño y separación del notch */
+    #bbdd-confirm{
+      position: fixed;                /* siempre visible */
+      right: clamp(10px, 3vw, 20px);  /* despega del borde */
+      top: calc(env(safe-area-inset-top, 0px) + 10px);
+      z-index: 60;
+      width: clamp(170px, 23vw, 270px); /* nunca ocupa todo el ancho */
+      pointer-events: auto;
+    }
+    
+    /* En pantallas angostas, deja aire a la izquierda para no tapar la flecha */
+    @media (max-width: 520px){
+      #bbdd-confirm{
+        left: unset;                 /* que mande por derecha */
+        right: 12px;
+      }
+    }
+    
+    /* 3) Ganar espacio horizontal en el overlay y en el “editor” */
+    #bbdd-overlay{
+      padding: clamp(4px, 0.8vh, 8px);                /* menos borde exterior */
+    }
+    .bbdd-panel{
+      border-radius: 14px;                             /* un poco menos de radio */
+    }
+    
+    /* Header y main más “pegados” a los bordes */
+    header.appbar{
+      padding: 10px clamp(10px, 3vw, 18px) 8px;       /* menos padding lateral/vertical */
+    }
+    main{
+      /* menos padding lateral; mantené el padding inferior del footer */
+      padding: 0 clamp(8px, 2.4vw, 14px) clamp(90px, 12vh, 150px);
+    }
+    
+    /* Cards más compactas y con menos aire a los lados */
+    .item{ margin: 6px 0; }
+    .slidable{
+      padding: 8px 10px;           /* menos padding interno */
+      column-gap: 6px;             /* controles más cerca */
+      border-radius: 14px;
+    }
+    .slidable .content{ min-width: 0; }
+    .task-input{ padding: 7px 9px; border-radius: 10px; }
+    
+    /* Chips y botón “…” más compactos */
+    .diff-chip, .more{ height: 34px; }
+    .diff-chip{ padding: 0 10px; }
+    
+    /* Barrita izquierda más finita para ganar 2 px de texto */
+    .slidable .mark{ width: 4px; }
+    
+    /* En móviles, todavía más apretado en los costados */
+    @media (max-width: 420px){
+      header.appbar{ padding: 8px 10px; }
+      main{ padding-left: 8px; padding-right: 8px; }
+      .slidable{ padding: 7px 8px; column-gap: 5px; }
+    }
+    
+    /* Opcional: afinar bordes generales del panel para ganar 1–2 px por lado */
+    .bbdd-panel{ border-width: 0.5px; }
+
+
+    /* ==========================================================Botón con spinner cuando está ocupado */
+    #bbdd-confirm {
+      position: fixed;
+      right: clamp(10px, 3vw, 20px);
+      top: calc(env(safe-area-inset-top, 0px) + 10px);
+      z-index: 60;
+      width: var(--confirm-w, clamp(160px, 40vw, 300px));
+    }
+    
+    @keyframes btnspin{ to { transform: rotate(360deg); } }
+    
+    /* Mientras guarda: bloqueá interacciones del panel (excepto el botón) */
+    .bbdd-panel.saving main,
+    .bbdd-panel.saving header.appbar,
+    .bbdd-panel.saving .bbdd-footer{
+      pointer-events: none;
+      user-select: none;
+      opacity: .92;
+      filter: grayscale(.1);
+    }
+    /* re-habilitá el botón confirm (queda por arriba) */
+    .bbdd-panel.saving #bbdd-confirm{
+      pointer-events: auto;
+    }
+    
+    /* Cursor de ocupado en todo el panel */
+    .bbdd-panel[aria-busy="true"]{ cursor: progress; }
+    /* --- escudo de bloqueo global --- */
+    #saving-shield{
+      position: fixed;        /* tapa todo el panel */
+      inset: 0;
+      z-index: 55;            /* por debajo del botón */
+      background: transparent;/* no ensucia la UI */
+      display: none;
+      touch-action: none;
+      pointer-events: none;
+    }
+    .bbdd-panel.saving #saving-shield{
+      display: block;
+      pointer-events: auto;   /* bloquea clics/gestos en todo */
+      /* opcional: bloquear scroll del panel */
+      overscroll-behavior: contain;
+    }
+    
+    /* --- spinner dentro del botón --- */
+    #bbdd-confirm{
+      position: fixed;
+      right: clamp(10px, 3vw, 20px);
+      top: calc(env(safe-area-inset-top, 0px) + 10px);
+      z-index: 60;                         /* por arriba del shield */
+      width: var(--confirm-w, clamp(160px, 40vw, 300px));
+      position: fixed;
+      overflow: visible;                    /* por si el spinner se acerca al borde */
+    }
+ 
+    
+    @keyframes spin{to{transform:rotate(360deg)}}
+    
+    /* asegurar que el shield bloquee todo mientras guarda */
+    .bbdd-panel.saving{ position:relative; }
+
+    /* ==== ÚNICO spinner del botón confirmar ==== */
+    #bbdd-confirm{
+      position: fixed;
+      right: clamp(10px, 3vw, 20px);
+      top: calc(env(safe-area-inset-top, 0px) + 10px);
+      z-index: 60;
+      width: clamp(170px, 23vw, 270px);
+      overflow: visible; /* por si acaso */
+    }
+    
+    #bbdd-confirm.is-busy{
+      color: transparent;     /* oculto label */
+      pointer-events: none;   /* anti doble click */
+      opacity: .95;
+    }
+    
+    #bbdd-confirm.is-busy::after{
+      content:"";
+      position:absolute;
+      inset:0;                /* centra el pseudo-elemento */
+      margin:auto;
+      width:18px; height:18px;
+      border-radius:50%;
+      border:2px solid rgba(255,255,255,.35);
+      border-top-color:#fff;
+      animation: btnspin .8s linear infinite;
+    }
+    
+    @keyframes btnspin { to { transform: rotate(360deg); } }
+
+    /* ==== GLASS LIGHT PATCH (pegar al final) ==== */
+    :root{
+      --glass-bg: rgba(255,255,255,.08);     /* cuerpo de la tarjeta */
+      --glass-stroke: rgba(255,255,255,.22); /* borde claro */
+      --glass-soft: rgba(255,255,255,.06);   /* secciones internas */
+    }
+    
+    /* Overlay más claro y “blanco” */
+    #bbdd-overlay{
+      background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04));
+      backdrop-filter: blur(22px) saturate(160%) brightness(1.15);
+      -webkit-backdrop-filter: blur(22px) saturate(160%) brightness(1.15);
+    }
+    
+    /* Panel principal en vidrio claro */
+    .bbdd-panel{
+      background: var(--glass-bg);
+      border-color: var(--glass-stroke);
+      box-shadow: 0 20px 50px rgba(24,28,50,.35);
+    }
+    
+    /* Un glow suave en el borde superior del panel (como tus flechas verdes) */
+    .bbdd-panel::before{
+      content:"";
+      position:absolute; inset:-1px; border-radius:inherit; pointer-events:none;
+      background:
+        radial-gradient(600px 160px at 15% -10%, rgba(255,255,255,.15), transparent 60%),
+        radial-gradient(600px 160px at 85% -10%, rgba(255,255,255,.12), transparent 60%);
+    }
+    
+    /* Secciones internas con vidrio claro */
+    header.appbar,
+    .slidable,
+    .meta,
+    .field,
+    details.guide{
+      background: var(--glass-soft);
+      border-color: rgba(255,255,255,.18);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.08), var(--shadow);
+    }
+    
+    /* Inputs más claros (sin perder contraste) */
+    .task-input{
+      background: rgba(255,255,255,.05);
+      border-color: rgba(255,255,255,.22);
+    }
+    .meta select,.meta input{
+      background: rgba(255,255,255,.04);
+      border-color: rgba(255,255,255,.18);
+    }
+
+    /* ===== Glass claro con SCRIM que tapa lo de atrás ===== */
+    :root{
+      --overlay-scrim: .42;   /* 0.35–0.50: cuánto oscurece el overlay sobre el fondo */
+      --panel-alpha:   .73;   /* 0.70–0.85: opacidad del panel (más alto = menos se ve atrás) */
+      --card-alpha:    .79;   /* opacidad de las tarjetas/filas (ajustá si aún ves algo) */
+    }
+    
+    /* Overlay: sigue con blur, pero le sumamos una veladura (scrim) encima */
+    #bbdd-overlay{
+      position: fixed;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04));
+      backdrop-filter: blur(22px) saturate(160%) brightness(1.12);
+      -webkit-backdrop-filter: blur(22px) saturate(160%) brightness(1.12);
+    }
+    
+    /* SCRIM que realmente tapa el contenido del dashboard detrás del overlay */
+    #bbdd-overlay::before{
+      content:"";
+      position:absolute;
+      inset:0;
+      background: rgba(12,16,28,var(--overlay-scrim));  /* <- subí/bajá esta perilla */
+      z-index: 0;
+    }
+    
+    /* Todo lo de adentro (panel) por encima del scrim */
+    #bbdd-overlay > *{ position: relative; z-index: 1; }
+    
+    /* Panel principal con vidrio claro pero más “opaco” (no se ve lo de atrás) */
+    .bbdd-panel{
+      background: rgba(28,34,52,var(--panel-alpha));     /* <- perilla 2 */
+      border-color: rgba(255,255,255,.22);
+      box-shadow: 0 20px 50px rgba(24,28,50,.35);
+    }
+    
+    /* Tarjetas/filas con un poco más de cuerpo (evita ver los 3 botones a través) */
+    .slidable{
+      background: rgba(18,24,40,var(--card-alpha));      /* <- perilla 3 */
+      border-color: rgba(255,255,255,.14);}
+
+    /* ==== Bloquear scroll horizontal y cualquier desborde ==== */
+
+    /* 1) La página completa nunca scrollea en X */
+    html, body{
+      overflow-x: hidden;                 /* <- clave */
+    }
+
+    /* ===== Ocultar acciones cuando la fila está cerrada ===== */
+    .item .actions{
+      /* que NO se vea ni reciba eventos por defecto */
+      opacity: 0;
+      pointer-events: none;
+      background: transparent !important;
+      transition: opacity .18s ease, background .18s ease;
+    }
+    
+    /* Los botones circulares por defecto: invisibles y sin borde */
+    .item .actions .act{
+      opacity: 0;
+      background: transparent !important;
+      border-color: transparent !important;
+      box-shadow: none !important;
+      transition: opacity .18s ease,
+                  background .18s ease,
+                  border-color .18s ease,
+                  transform .18s ease;
+    }
+    
+    /* ===== Peek: apenas se asoman cuando arrastrás unos px ===== */
+    .item.row-peek .actions{
+      /* un velo MUY suave; podés bajar más el .5 si querés menos */
+      background: linear-gradient(90deg, transparent 55%, rgba(10,14,28,.5) 100%) !important;
+      opacity: .6;
+    }
+    .item.row-peek .actions .act{
+      opacity: .35;                                    /* se insinúan */
+      background: rgba(32,38,66,.25) !important;       /* suave */
+      border-color: rgba(125,60,255,.18) !important;   /* borde tenue */
+      box-shadow: none !important;
+    }
+    
+    /* ===== Open: ya abiertas, todo visible y clickeable ===== */
+    .item.row-open .actions{
+      opacity: 1;
+      pointer-events: auto;
+      background: linear-gradient(90deg, transparent 32%, rgba(10,14,28,.88) 100%) !important;
+    }
+    .item.row-open .actions .act{
+      opacity: 1;
+      background: rgba(32,38,66,.88) !important;
+      border-color: rgba(125,60,255,.35) !important;
+      box-shadow: 0 6px 18px rgba(0,0,0,.32) !important;
+    }
+    
+    /* Por si algún estilo previo del tema “oscurece” los botones,
+       forzamos que CERRADA/PEEK no herede sombras ni fills */
+    .item:not(.row-open) .actions .act.modify,
+    .item:not(.row-open) .actions .act.improve,
+    .item:not(.row-open) .actions .act.del{
+      box-shadow: none !important;
+    }
+
+
+
+    
+    /* ====== Anti-rebote horizontal (iOS/Android) ====== */
+    /* 1) Nada de scroll X en la página */
+    html, body{
+      max-width: 100%;
+      overflow-x: hidden;
+      overscroll-behavior-x: none;   /* evita el rubber-band lateral */
+      touch-action: pan-y;           /* solo gestos verticales a nivel página */
+    }
+    
+    /* 2) El overlay y el panel tampoco permiten desplazamiento X ni rebote */
+    #bbdd-overlay,
+    .bbdd-panel{
+      overflow-x: hidden;
+      overscroll-behavior: contain;  /* no propaga el overscroll al viewport */
+      touch-action: pan-y;           /* solo vertical aquí */
+    }
+    
+    /* 3) PERO: las tarjetas sí pueden escuchar gesto horizontal para el swipe */
+    .item .slidable{
+      touch-action: pan-x pan-y;     /* habilita el deslizamiento lateral del row */
+    }
+    
+    /* Por si algún contenedor introduce 1px de ancho de más */
+    #table-wrap, #bbdd-table{
+      max-width: 100%;
+      overflow-x: hidden;
+    }
+
+    /* ===== Scrollbar sutil dentro del panel ===== */
+    .bbdd-panel{
+      /* Firefox */
+      scrollbar-width: thin;
+      scrollbar-color: rgba(180,190,220,.18) transparent;
+    }
+    /* WebKit (Chrome, Edge, Safari) */
+    .bbdd-panel::-webkit-scrollbar{
+      width: 10px;                 /* grosor total de la barra */
+    }
+    .bbdd-panel::-webkit-scrollbar-track{
+      background: transparent;     /* sin “pista” visible */
+    }
+    .bbdd-panel::-webkit-scrollbar-thumb{
+      /* pulgar casi invisible, con borde transparente para que se “adelgace” */
+      background: linear-gradient(180deg,
+                  rgba(180,190,220,.30),
+                  rgba(125,60,255,.35));
+      border-radius: 999px;
+      border: 3px solid transparent;
+      background-clip: content-box;  /* truco para que se vea finito */
+      opacity: .65;
+      transition: opacity .2s ease, background .2s ease;
+    }
+    /* al pasar el mouse por el panel, aparece un poco más */
+    .bbdd-panel:hover::-webkit-scrollbar-thumb{
+      opacity: .9;
+      background: linear-gradient(180deg,
+                  rgba(200,210,240,.45),
+                  rgba(140,92,255,.55));
+    }
+    /* esquina para macOS con ambos scrollbars */
+    .bbdd-panel::-webkit-scrollbar-corner{ background: transparent; }
+
+    /* ===== Destellos suaves (mismo lenguaje que el dashboard) ===== */
+    :root{
+      --glow-cyan:  rgba(80,180,255,.25);
+      --glow-violet:rgba(160,100,255,.22);
+      --glow-rose:  rgba(255,120,200,.16);
+    }
+    
+    /* halo en el overlay (detrás del panel) */
+    #bbdd-overlay::before{
+      content:"";
+      position:fixed;
+      inset:-20%;
+      pointer-events:none;
+      background:
+        radial-gradient(800px 400px at 20% 0%,   var(--glow-cyan),  transparent 60%),
+        radial-gradient(700px 360px at 85% -5%,  var(--glow-violet),transparent 65%),
+        radial-gradient(600px 320px at 60% 120%, var(--glow-rose),  transparent 65%);
+      filter: blur(6px);
+      z-index: 0; /* por debajo del panel */
+    }
+    
+    /* halo interno del panel (muy suave) */
+    .bbdd-panel{
+      position: relative; /* asegurar stacking */
+    }
+    .bbdd-panel::before{
+      content:"";
+      position:absolute;
+      inset:-1px;
+      border-radius: inherit;
+      pointer-events:none;
+      background:
+        radial-gradient(520px 160px at 18% -8%, rgba(255,255,255,.14), transparent 60%),
+        radial-gradient(520px 160px at 82% -8%, rgba(255,255,255,.12), transparent 60%);
+      z-index: 0;
+    }
+
+/* ===== Offline ===== */
+.offline-body{
+  min-height:100vh;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:24px;
+  background:var(--bg);
+  color:var(--ink);
+  font-family:"Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+}
+.offline-card{
+  max-width:420px;
+  background:rgba(16,23,38,.88);
+  border:1px solid rgba(125,60,255,.25);
+  border-radius:16px;
+  padding:28px;
+  box-shadow:0 20px 44px rgba(0,0,0,.35);
+}
+.offline-card a{
+  color:var(--accent);
+  font-weight:600;
+}

--- a/refactor/js/features/bbdd.js
+++ b/refactor/js/features/bbdd.js
@@ -1,0 +1,1394 @@
+/**
+ * Módulo: BBDDEditor
+ * Propósito: replicar la consola de edición y confirmación de BBDD.
+ * API pública: init()
+ * Dependencias: DOM estándar, fetch.
+ * Side-effects: localStorage/sessionStorage, listeners globales y window.* helpers.
+ * Notas de accesibilidad: gestiona foco, aria-live y bloqueo de UI al confirmar.
+ */
+
+/* ====== Config ====== */
+// PRODUCCIÓN: apuntá al Worker
+const API_BASE = "https://gamificationbbddedit.rfullivarri22.workers.dev/api";
+const PROXY_KEY = "bbddconfig2332"; // misma que pusiste en el Worker
+const DASHBOARD_URL = "https://rfullivarri.github.io/gamificationweblanding/dashboardv3.html";
+
+/* ====== Catálogos ====== */
+const PILARES_OPTS = ["Body", "Mind", "Soul"];
+const DIFICULTAD_OPTS = ["Fácil", "Media", "Difícil"];
+const RASGOS_POR_PILAR = {
+  Body: ["Energía","Nutrición","Sueño","Recuperación","Hidratación","Higiene","Vitalidad","Postura","Movilidad","Moderación"],
+  Mind: ["Enfoque","Aprendizaje","Creatividad","Gestión","Autocontrol","Resiliencia","Orden","Proyección","Finanzas","Agilidad"],
+  Soul: ["Conexión","Espiritualidad","Propósito","Valores","Altruismo","Insight","Gratitud","Naturaleza","Gozo","Autoestima"],
+};
+const RASGOS_COMBO = Object.entries(RASGOS_POR_PILAR)
+  .flatMap(([pilar, rasgos]) => rasgos.map(r => `${r}, ${pilar}`));
+
+/* ====== Util ====== */
+const qs = sel => document.querySelector(sel);
+const qsa = sel => [...document.querySelectorAll(sel)];
+const param = (k) => new URL(location.href).searchParams.get(k);
+const email = (param("email") || localStorage.getItem("gj_email") || "").trim().toLowerCase();
+
+function hashRows(rows){
+  // rows: array de arrays (A-E)
+  const s = rows.map(r => r.map(v => (v??"").toString().trim()).join("|")).join("||");
+  // djb2 simple
+  let h=5381; for(const ch of s) h=((h<<5)+h)+ch.charCodeAt(0); return h>>>0;
+}
+function cleanRasgo(s){
+  s = (s||"").trim();
+  return s.includes(",") ? s.split(",")[0].trim() : s;
+}
+function normPilar(v){
+  const map = { body:"Body", cuerpo:"Body", mind:"Mind", mente:"Mind", soul:"Soul", alma:"Soul" };
+  const k = (v||"").toString().trim().toLowerCase();
+  return map[k] || (v||"").toString().trim();
+}
+function normDiff(v){
+  const map = { facil:"Fácil","fácil":"Fácil", media:"Media", medio:"Media", dificil:"Difícil","difícil":"Difícil" };
+  const k = (v||"").toString().trim().toLowerCase();
+  return map[k] || (v||"").toString().trim();
+}
+function toast(msg, ok=true, ms=3200){
+  const el = qs("#status-msg");
+  el.textContent = msg;
+  el.style.color = ok ? "#9ff7cc" : "#ff8a9b";
+  setTimeout(()=>{ el.textContent=""; }, 4000);
+}
+
+// ===== [Estado] =====
+let state = {
+  rows: [],          // [[Pilar,Rasgo,Stats,Tasks,Dificultad,Feedback]]
+  origHash: null,
+  dirty: false,
+  filter: "",
+  aiUpdated: new Set(),
+};
+
+window.state = state;
+
+
+
+
+// ===== [API adapters] =====
+async function apiGetBBDD(email){
+  const r = await fetch(`${API_BASE}/bbdd?email=${encodeURIComponent(email)}`, {
+    credentials:"include",
+    headers: { "X-Proxy-Key": PROXY_KEY }
+  });
+  if(!r.ok) throw new Error("Error al cargar BBDD");
+  return r.json();
+}
+async function apiSaveBBDD(email, rows){
+  const r = await fetch(`${API_BASE}/bbdd`, {
+    method:"POST",
+    headers:{ "Content-Type":"application/json", "X-Proxy-Key": PROXY_KEY },
+    body: JSON.stringify({ email, rows })
+  });
+  if(!r.ok) throw new Error("Error al guardar BBDD");
+  return r.json();
+}
+async function apiConfirmBBDD(email){
+  const r = await fetch(`${API_BASE}/bbdd/confirm`, {
+    method:"POST",
+    headers:{ "Content-Type":"application/json", "X-Proxy-Key": PROXY_KEY },
+    body: JSON.stringify({ email })
+  });
+  if(!r.ok) throw new Error("Error al confirmar cambios");
+  return r.json();
+}
+
+// ===== [UI: render] =====
+function render(){
+  const tbody = qs("#bbdd-tbody");
+  tbody.innerHTML = "";
+
+  const term = state.filter.toLowerCase();
+
+  state.rows.forEach((row, realIdx) => {
+    // aplicar filtro sin perder índice real
+    if (term) {
+      const hay = row.join(" ").toLowerCase().includes(term);
+      if (!hay) return;
+    }
+
+    const tr = document.createElement("tr");
+    tr.draggable = true;
+    tr.dataset.index = realIdx; // << índice REAL en state.rows
+    tr.innerHTML = `
+      <td>${selectPilar(row[0])}</td>
+      <td>${selectRasgo(row[1], row[0])}</td>
+      <td>${inputText(row[2], "Stats")}</td>
+      <td>${inputText(row[3], "Tasks")}</td>
+      <td>${selectDiff(row[4])}</td>
+      <td>${feedbackButtons(row[5]||"")}</td>
+      <td class="row-actions">
+        <span class="handle" title="Arrastrar">⋮⋮</span>
+        <button class="mini" data-act="del">X</button>
+      </td>
+    `;
+    if (state.aiUpdated.has(realIdx)) {
+      tr.querySelector('input[data-col="3"]').classList.add("ai-updated");
+    }
+    tr.addEventListener("input", onRowInput);
+    tr.addEventListener("click", onRowClick);
+    tr.addEventListener("dragstart", onDragStart);
+    tr.addEventListener("dragover", onDragOver);
+    tr.addEventListener("drop", onDrop);
+
+    tbody.appendChild(tr);
+  });
+
+  qs("#dirty-indicator").classList.toggle("hidden", !state.dirty);
+}
+
+function selectPilar(val){
+  const opts = Array.from(new Set([...PILARES_OPTS])); // podríamos sumar existentes si querés
+  const html = opts.map(o => `<option ${o===val?"selected":""}>${o}</option>`).join("");
+  return `<select data-col="0">${html}</select>`;
+}
+function selectRasgo(val, pilarActual){
+  const p = normPilar(pilarActual||"");
+  const base = RASGOS_POR_PILAR[p] || [];
+  const opts = Array.from(new Set([val, ...base])).filter(Boolean);
+  const html = opts.map(o => `<option ${o===val?"selected":""}>${o}</option>`).join("");
+  return `<select data-col="1">${html}</select>`;
+}
+function selectDiff(val){
+  const opts = Array.from(new Set([...DIFICULTAD_OPTS, val].filter(Boolean)));
+  const html = opts.map(o => `<option ${o===val?"selected":""}>${o}</option>`).join("");
+  return `<select data-col="4">${html}</select>`;
+}
+function inputText(val, placeholder){
+  const v = (val??"").toString().replace(/"/g,"&quot;");
+  return `<input class="input" data-col="2or3" placeholder="${placeholder}" value="${v}"/>`.replace("2or3", placeholder==="Stats"?"2":"3");
+}
+function feedbackButtons(current){
+  const is = k => current===k ? "active" : "";
+  return `
+    <div class="feedback" data-col="5">
+      <button data-fb="improve" class="${is("improve")}" title="Mejorar esta task">🪄</button>
+      <button data-fb="replace" class="${is("replace")}" title="Modificar esta task">🔁</button>
+    </div>
+  `;
+}
+
+/* ====== Handlers ====== */
+function markDirty(){
+  state.dirty = true;
+  const dot = document.querySelector("#dirty-indicator");
+  if (dot) dot.classList.remove("hidden"); // sin re-render
+}
+
+function onRowInput(e){
+  const tr = e.currentTarget;
+  const idx = Number(tr.dataset.index);
+  const t = e.target;
+
+  if(t.matches("select,[data-col]")){
+    const col = Number(t.dataset.col);
+    let val = t.value;
+
+    if (col===0){            // Pilar cambió
+      val = normPilar(val);
+      state.rows[idx][0] = val;
+    
+      const rasgoActual = cleanRasgo(state.rows[idx][1]);
+      if (!RASGOS_POR_PILAR[val]?.includes(rasgoActual)) {
+        state.rows[idx][1] = "";
+      }
+      markDirty();
+      render();              // <-- sólo acá
+      return;
+    }
+    // col 1/2/3/4:
+    if (col===1) val = cleanRasgo(val);
+    if (col===4) val = normDiff(val);
+    state.rows[idx][col] = val;
+    markDirty();            // <-- sin render
+  }
+}
+
+function onRowClick(e){
+  const tr = e.currentTarget;
+  const idx = Number(tr.dataset.index);
+  const t = e.target;
+
+  // feedback por fila
+  if (t.closest(".feedback")){
+    const fb = t.dataset.fb; // "improve" | "replace"
+    if(!fb) return;
+    const wasActive = t.classList.contains("active");
+    state.rows[idx][5] = wasActive ? "" : fb; // toggle
+    const box = t.closest(".feedback");
+    box.querySelectorAll("button").forEach(b=>b.classList.remove("active"));
+    if (!wasActive) t.classList.add("active");
+    markDirty();
+    return;
+  }
+
+  // eliminar fila
+  if(t.dataset.act === "del"){
+    state.rows.splice(idx,1);
+  
+    // Reindexar el set de aiUpdated
+    const next = new Set();
+    for (const i of state.aiUpdated) {
+      if (i < idx) next.add(i);
+      else if (i > idx) next.add(i - 1);
+      // si i === idx, la fila borrada desaparece del set
+    }
+    state.aiUpdated = next;
+  
+    markDirty(); render();
+  }
+}
+
+// ===== [DnD] =====
+let dragIndex = null;
+function onDragStart(e){ dragIndex = Number(e.currentTarget.dataset.index); e.dataTransfer.effectAllowed="move"; }
+function onDragOver(e){ e.preventDefault(); e.dataTransfer.dropEffect="move"; }
+function onDrop(e){
+  e.preventDefault();
+  const to = Number(e.currentTarget.dataset.index);
+  if(dragIndex===null || to===dragIndex) return;
+
+  // mover la fila
+  const [item] = state.rows.splice(dragIndex,1);
+  state.rows.splice(to,0,item);
+
+  // mover también la marca aiUpdated si corresponde
+  const moved = state.aiUpdated.has(dragIndex);
+  const next = new Set();
+  for (const i of state.aiUpdated) {
+    if (i === dragIndex) continue;         // se reubicará
+    // corregir índices que quedaron entre medio
+    if (dragIndex < to)       next.add(i > dragIndex && i <= to ? i - 1 : i);
+    else if (dragIndex > to)  next.add(i >= to && i < dragIndex ? i + 1 : i);
+    else                      next.add(i);
+  }
+  if (moved) next.add(to);
+  state.aiUpdated = next;
+
+  dragIndex = null;
+  markDirty(); render();
+}
+
+/*====HELPERS=====*/
+function setTableLoading(on){
+  qs("#table-wrap").classList.toggle("table-loading", on);
+  const spin = qs("#table-spinner");
+  if (!spin) return;
+  spin.style.display = on ? "" : "none"; // deja que el CSS ponga display:flex
+}
+
+function aiLoading(on){
+  const wrap = qs("#table-wrap");
+  if(!wrap) return;
+  wrap.classList.toggle("ai-loading", !!on);
+}
+
+/* === Polyfill/bridge: setDot seguro si el dashboard no está cargado === */
+function _localSetDot(el, on, color = '#ffc107') {
+  if (!el) return;
+  let dot = el.querySelector(':scope > .dot');
+  if (on) {
+    if (!dot) {
+      dot = document.createElement('span');
+      dot.className = 'dot';
+      el.appendChild(dot);
+    }
+    dot.style.background = color;
+    // posición especial sólo para la hamburguesa
+    if (el.id === 'menu-toggle') {
+      dot.style.top = '-2px';
+      dot.style.right = '-2px';
+    } else {
+      dot.style.top = '';
+      dot.style.right = '';
+    }
+  } else if (dot) {
+    dot.remove();
+  }
+}
+
+/* Usa window.setDot si existe; si no, usa el local para que no falle */
+const setDotSafe = (typeof window !== 'undefined' && typeof window.setDot === 'function')
+  ? window.setDot
+  : _localSetDot;
+
+
+/* ====== Actions ====== */
+function currentVisibleRows(){
+  // devuelve matriz A-E (ignora feedback para guardar)
+  return state.rows.map(r => [ normPilar(r[0]), cleanRasgo(r[1]), (r[2]||""),(r[3]||""), normDiff(r[4]) ]);
+}
+
+async function doSave(){
+  const rows = currentVisibleRows()
+    .filter(r => r.some(v => (v||"").toString().trim()!=="")); // quita filas totalmente vacías
+
+  // validaciones mínimas
+  for(const r of rows){
+    if(!["Body","Mind","Soul"].includes(r[0])) return toast("Pilar inválido. Usá Body/Mind/Soul.", false);
+    if(!r[3]) return toast("La columna 'Tasks' no puede estar vacía.", false);
+  }
+
+  await apiSaveBBDD(email, rows);
+  state.origHash = hashRows(rows);
+  state.dirty = false;
+  state.aiUpdated.clear();
+  toast("✅ Guardado");
+  render();
+}
+
+async function doConfirm(){
+  const btn = document.querySelector("#bbdd-confirm");
+  // START loading UI
+  btn.disabled = true;
+  btn.classList.add("loading");
+  btn.setAttribute("aria-busy", "true");
+
+  try {
+    // 1) Construir A–E desde el estado actual (normalizado)
+    const rows = currentVisibleRows().filter(r =>
+      r.some(v => (v||"").toString().trim()!=="")
+    );
+
+    // 2) Guardar en servidor (decide estado y escribe Setup!E14)
+    let saveRes;
+    try {
+      saveRes = await apiSaveBBDD(email, rows); // { ok, estado, ... }
+    } catch (err) {
+      toast("Error al guardar: " + err.message, false);
+      return; // <- el finally re-activa el botón
+    }
+
+    const estado = (saveRes && saveRes.estado) || "constante";
+    if (estado === "constante"){
+      toast("✅ No hubo cambios (estado: constante)");
+      state.dirty = false;
+      // No re-render masivo aquí para no perder foco; sólo ocultá el dot:
+      const dot = document.querySelector("#dirty-indicator");
+      if (dot) dot.classList.add("hidden");
+      return; // <- no confirm → no BOBO
+    }
+
+    // 3) Confirmar (marca F/G y dispara BOBO)
+    try {
+      await apiConfirmBBDD(email);
+      state.dirty = false;
+      state.aiUpdated.clear();
+      render();
+      toast("✅ Cambios confirmados. ¡Estamos configurando tu Daily Quest!");
+
+      // === UI Onboarding: si es PRIMERA vez, avisar al dashboard de forma inmediata ===
+      const isFirst = String(estado || '').toLowerCase() === 'primera';
+      if (isFirst) {
+        try {
+          // 1) avisar al DASHBOARD (funciona en overlay/iframe o en otra pestaña)
+          try {
+            window.parent?.postMessage(
+              { kind: 'GJ_ONBOARD', step: 'BBDD_CONFIRMED', estado: 'primera', email },
+              '*'
+            );
+          } catch {}
+      
+          // 2) fallback si navega al dashboard en el mismo tab
+          try { sessionStorage.setItem('gj_onboarding', 'primera'); } catch {}
+      
+          // 3) one-shot legacy por si el dashboard aún no tenía el listener
+          try { localStorage.setItem(`gj_force_scheduler_banner:${(email||'').toLowerCase()}`, '1'); } catch {}
+        } catch {}
+      }
+
+    } catch (err) {
+      toast("Error en confirmación: " + err.message, false);
+      return;
+    }
+
+    // 4) Cerrar / volver (sin navegar para que el banner quede visible en el dashboard)
+    setTimeout(()=>{
+      if(window.BBDD_MODE==="modal"){
+        window.GJ_AUTO?.poke();  //LLAMA A CONSULTAR EL REFRESH KV
+        closeOverlay();    // el dashboard ya está detrás y con el banner mostrado
+      } else {
+        // Si preferís navegar igualmente, podés reactivar esta línea:
+        // location.href = `${DASHBOARD_URL}?email=${encodeURIComponent(email)}`;
+      }
+    }, 300);
+
+  } finally {
+    // END loading UI (se ejecuta SIEMPRE, incluso si hubo return/throw)
+    btn.disabled = false;
+    btn.classList.remove("loading");
+    btn.removeAttribute("aria-busy");
+  }
+}
+
+window.doConfirm = doConfirm;
+
+
+// /* ====== Actions ====== */
+// function currentVisibleRows(){
+//   // devuelve matriz A-E (ignora feedback para guardar)
+//   return state.rows.map(r => [ normPilar(r[0]), cleanRasgo(r[1]), (r[2]||""),(r[3]||""), normDiff(r[4]) ]);
+// }
+
+// async function doSave(){
+//   const rows = currentVisibleRows()
+//     .filter(r => r.some(v => (v||"").toString().trim()!=="")); // quita filas totalmente vacías
+
+//   // validaciones mínimas
+//   for(const r of rows){
+//     if(!["Body","Mind","Soul"].includes(r[0])) return toast("Pilar inválido. Usá Body/Mind/Soul.", false);
+//     if(!r[3]) return toast("La columna 'Tasks' no puede estar vacía.", false);
+//   }
+
+//   await apiSaveBBDD(email, rows);
+//   state.origHash = hashRows(rows);
+//   state.dirty = false;
+//   state.aiUpdated.clear();
+//   toast("✅ Guardado");
+//   render();
+// }
+
+// async function doConfirm(){
+//   const btn = document.querySelector("#bbdd-confirm");
+//   // START loading UI
+//   btn.disabled = true;
+//   btn.classList.add("loading");
+//   btn.setAttribute("aria-busy", "true");
+
+//   try {
+//     // 1) Construir A–E desde el estado actual (normalizado)
+//     const rows = currentVisibleRows().filter(r =>
+//       r.some(v => (v||"").toString().trim()!=="")
+//     );
+
+//     // 2) Guardar en servidor (decide estado y escribe Setup!E14)
+//     let saveRes;
+//     try {
+//       saveRes = await apiSaveBBDD(email, rows); // { ok, estado, ... }
+//     } catch (err) {
+//       toast("Error al guardar: " + err.message, false);
+//       return; // <- el finally re-activa el botón
+//     }
+
+//     const estado = (saveRes && saveRes.estado) || "constante";
+//     if (estado === "constante"){
+//       toast("✅ No hubo cambios (estado: constante)");
+//       state.dirty = false;
+//       // No re-render masivo aquí para no perder foco; sólo ocultá el dot:
+//       const dot = document.querySelector("#dirty-indicator");
+//       if (dot) dot.classList.add("hidden");
+//       return; // <- no confirm → no BOBO
+//     }
+
+//     // 3) Confirmar (marca F/G y dispara BOBO)
+//     try {
+//       await apiConfirmBBDD(email);
+//       state.dirty = false;
+//       state.aiUpdated.clear();
+//       render();
+//       toast("✅ Cambios confirmados. ¡Estamos configurando tu Daily Quest!");
+    
+//       // === UI Onboarding (optimista estricta): solo si estado === "primera" ===
+//       const isFirst = String(estado || '').toLowerCase() === 'primera';
+    
+//       if (isFirst) {
+//         try {
+//           // 1) Ocultar banners de BBDD si están visibles
+//           ['journey-warning','bbdd-warning'].forEach(id => {
+//             const el = document.getElementById(id);
+//             if (el && getComputedStyle(el).display !== 'none') el.style.display = 'none';
+//           });
+    
+//           // 2) Apagar dots de BBDD en menú (usa polyfill seguro)
+//           setDotSafe(document.getElementById('menu-toggle'), false);
+//           setDotSafe(document.getElementById('li-edit-bbdd'), false);
+    
+//           // 3) Mostrar banner de Programar Daily + dots (no marcamos "visto" acá)
+//           const warn = document.getElementById('scheduler-warning');
+//           if (warn && getComputedStyle(warn).display === 'none') {
+//             warn.style.display = 'block';
+//           }
+//           setDotSafe(document.getElementById('menu-toggle'), true, '#ffc107');
+//           setDotSafe(document.getElementById('open-scheduler'), true, '#ffc107');
+    
+//           // ⚠️ NO grabamos gj_sched_hint_shown acá: solo al hacer click en "Programar"
+//         } catch (uiErr) {
+//           console.warn('[BBDD UI] hint scheduler fallo suave:', uiErr);
+//         }
+//       }
+    
+//     } catch (err) {
+//       toast("❌ Error en confirmación: " + err.message, false);
+//       return;
+//     }
+
+//     // 4) Cerrar / volver
+//     setTimeout(()=>{
+//       if(window.BBDD_MODE==="modal"){
+//         closeOverlay();
+//         if(confirm("¿Volver al Dashboard?")){
+//           location.href = `${DASHBOARD_URL}?email=${encodeURIComponent(email)}`;
+//         }
+//       } else {
+//         location.href = `${DASHBOARD_URL}?email=${encodeURIComponent(email)}`;
+//       }
+//     }, 400);
+
+//   } finally {
+//     // END loading UI (se ejecuta SIEMPRE, incluso si hubo return/throw)
+//     btn.disabled = false;
+//     btn.classList.remove("loading");
+//     btn.removeAttribute("aria-busy");
+//   }
+// }
+
+/* ====== Clipboard paste ====== */
+async function pasteFromClipboard(){
+  try{
+    const text = await navigator.clipboard.readText();
+    if(!text) return;
+    const lines = text.split(/\r?\n/).map(l=>l.split("\t"));
+    // mapeamos columnas 0..4 como A-E
+    for(const cols of lines){
+      if(cols.every(c=>!c)) continue;
+      const row = [
+        normPilar(cols[0]||""),
+        cleanRasgo(cols[1]||""),
+        (cols[2]||""),
+        (cols[3]||""),
+        normDiff(cols[4]||""),
+        "" // feedback
+      ];
+      state.rows.push(row);
+    }
+    markDirty(); render();
+  }catch(err){ toast("No pude leer el portapapeles", false); }
+}
+
+/* ====== Filtro ====== */
+function onFilter(e){ state.filter = e.target.value; render(); }
+
+/* ====== Overlay control ====== */
+function openOverlay(){
+  qs("#bbdd-overlay").classList.remove("hidden");
+  document.body.style.overflow = "hidden";
+}
+function closeOverlay(){
+  if(state.dirty && !confirm("Tenés cambios sin guardar. ¿Cerrar igualmente?")) return;
+  qs("#bbdd-overlay").classList.add("hidden");
+  document.body.style.overflow = "";
+}
+
+
+
+
+/* ====== AI wiring ====== */
+
+// 1) Tomar selección con feedback y construir batch + mapa de índices reales
+function aiBuildSelection() {
+  const idxs = [];   // índices reales en state.rows
+  const batch = [];  // [[Pilar,Rasgo,Stat,Task,Dificultad,Acción], ...]
+  state.rows.forEach((r, i) => {
+    const fb = (r[5] || "").toLowerCase(); // "improve" | "replace"
+    if (fb === "improve" || fb === "replace") {
+      idxs.push(i);
+      batch.push([
+        normPilar(r[0] || ""),
+        cleanRasgo(r[1] || ""),
+        (r[2] || ""),
+        (r[3] || ""),
+        normDiff(r[4] || ""),
+        fb
+      ]);
+    }
+  });
+  return { idxs, batch };
+}
+
+// 2) POST al Worker de AI
+async function aiSendBatch(email, batch) {
+  const AI_API = "https://gamificationaicuratetask.rfullivarri22.workers.dev/"; // ok que esté acá
+  const url = AI_API;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, batch })
+  });
+
+  const text = await res.text();
+  let data;
+  try { data = JSON.parse(text); } catch { throw new Error("Respuesta no es JSON"); }
+
+  if (!res.ok) {
+    throw new Error(data?.error || `Error ${res.status}`);
+  }
+  if (!data?.results || !Array.isArray(data.results)) {
+    throw new Error("Respuesta sin 'results'");
+  }
+  return data.results; // [[Pilar,Rasgo,Stat,NuevaTask,Dificultad,Acción], ...]
+}
+
+// 3) Aplicar resultados a state.rows según índices
+function aiApplyResults(idxs, results) {
+  if (idxs.length !== results.length) {
+    throw new Error("Desfase resultados vs selección");
+  }
+  for (let k = 0; k < idxs.length; k++) {
+    const rowIndex = idxs[k];
+    const resultRow = results[k];
+    const newTask = (resultRow?.[3] || "").toString().trim();
+    if (newTask) {
+      state.rows[rowIndex][3] = newTask;  // pegar Task
+      state.rows[rowIndex][5] = "";       // limpiar feedback
+      state.aiUpdated.add(rowIndex);
+    }
+  }
+}
+
+window.aiApplyResults = aiApplyResults;
+
+// 4) Orquestador con chunking (para muchas filas)
+async function aiRunForSelection() {
+  const { idxs, batch } = aiBuildSelection();
+  if (!idxs.length) {
+    alert("Seleccioná al menos una fila con 🪄 o 🔁");
+    return;
+  }
+
+  // UI loading
+  aiLoading(true);
+ //setTableLoading(true);
+
+  try {
+    const CHUNK = 20; // podés subirlo si querés, 20–30 es sano
+    for (let start = 0; start < batch.length; start += CHUNK) {
+      const end = Math.min(start + CHUNK, batch.length);
+      const sliceIdxs = idxs.slice(start, end);
+      const sliceBatch = batch.slice(start, end);
+
+      const results = await aiSendBatch(email, sliceBatch);
+      aiApplyResults(sliceIdxs, results);
+      render(); // ver el progreso por tandas
+    }
+
+    markDirty(); // hay cambios locales sin guardar
+    toast("✅ Tareas generadas por AI. Revisá y guardá cuando estés conforme.");
+
+  } catch (err) {
+    console.error(err);
+    toast("Error al generar con AI: " + err.message, false);
+  } finally {
+    aiLoading(false);
+    setTableLoading(false);
+  }
+}
+
+
+
+
+
+
+// ===== [UI: extras portados del inline] =====
+function setupAppbarSnap(){
+  if (setupAppbarSnap.done) return;
+  setupAppbarSnap.done = true;
+  const panel  = document.querySelector('.bbdd-panel');
+  const appbar = document.querySelector('header.appbar');
+  const main   = document.querySelector('.bbdd-panel > main');
+  if(!panel || !appbar || !main) return;
+
+  const root = document.documentElement;
+
+  let lastY = panel.scrollTop;
+  let hide  = 0;
+  let H     = appbar.offsetHeight || 0;
+  let MAX   = Math.max(0, H - 6);
+  const K = 1;
+  const FRICTION = 0.13;
+
+  function applyVars(){
+    appbar.style.setProperty('--appbarHide', hide + 'px');
+    const pad = 0;
+    root.style.setProperty('--appbarPad', pad + 'px');
+    main.style.setProperty('--appbarPad', pad + 'px');
+  }
+
+  function recalcHeader(){
+    H   = appbar.offsetHeight || 0;
+    MAX = Math.max(0, H - 6);
+    hide = Math.min(hide, MAX);
+    applyVars();
+  }
+
+  new ResizeObserver(recalcHeader).observe(appbar);
+  recalcHeader();
+
+  panel.addEventListener('scroll', () => {
+    const y  = panel.scrollTop;
+    const dy = y - lastY;
+
+    if (dy > 0) {
+      hide += dy * K;
+    } else if (dy < 0) {
+      hide += dy * K * (1 - FRICTION);
+    }
+
+    hide = Math.min(Math.max(hide, 0), MAX);
+    applyVars();
+
+    if (y <= 0 && hide !== 0) {
+      hide = 0;
+      applyVars();
+    }
+
+    lastY = y;
+  }, { passive:true });
+}
+
+function detectMode(){
+  const q = new URLSearchParams(location.search);
+  const hasEmail = q.has('email') && q.get('email').trim() !== '';
+  window.BBDD_MODE = hasEmail ? 'page' : 'modal';
+}
+
+function setupMobileEnhancements(){
+  if (setupMobileEnhancements.done) return;
+  setupMobileEnhancements.done = true;
+  const dup = document.getElementById('add-row-dup');
+  if(dup){
+    dup.addEventListener('click', (e)=>{
+      e.preventDefault();
+      document.getElementById('add-row')?.click();
+    });
+  }
+
+  const originalAiApply = window.aiApplyResults;
+  if(typeof originalAiApply === 'function'){
+    window.aiApplyResults = function patchedAiApply(idxs, results){
+      if(Array.isArray(idxs) && window.state && Array.isArray(window.state.rows)){
+        idxs.forEach((rowIdx, pos)=>{
+          const row = window.state.rows[rowIdx];
+          if(!row) return;
+          let mode = '';
+          const res = Array.isArray(results) ? results[pos] : null;
+          if(res){
+            if(typeof res?.[5] === 'string') mode = res[5];
+            else if(typeof res?.action === 'string') mode = res.action;
+            else if(typeof res?.mode === 'string') mode = res.mode;
+          }
+          if(!mode && typeof row[5] === 'string'){
+            const hint = row[5].toLowerCase();
+            if(hint === 'improve' || hint === 'replace'){
+              mode = hint;
+            }
+          }
+          mode = (mode || '').toLowerCase();
+          if(mode && mode.includes('modify')) mode = 'replace';
+          if(mode && mode.includes('mejor')) mode = 'improve';
+          if(mode !== 'improve' && mode !== 'replace'){
+            mode = mode.includes('replace') ? 'replace' : (mode.includes('improve') ? 'improve' : mode);
+          }
+          if(mode === 'replace' || mode === 'improve'){
+            row.__aiMode = mode;
+          } else if(!row.__aiMode){
+            row.__aiMode = 'improve';
+          }
+        });
+      }
+      return originalAiApply.apply(this, arguments);
+    };
+  }
+
+  const tbody = document.getElementById('bbdd-tbody');
+  if(!tbody) return;
+
+  const observer = new MutationObserver((mutations)=>{
+    for(const m of mutations){
+      m.addedNodes.forEach(node => {
+        if(node.nodeType === 1 && node.matches('tr')){
+          enhanceRow(node);
+        }
+      });
+    }
+    requestAnimationFrame(armSwipeHint);
+  });
+  observer.observe(tbody,{childList:true});
+
+  requestAnimationFrame(()=>{
+    tbody.querySelectorAll('tr').forEach(enhanceRow);
+    armSwipeHint();
+  });
+
+  let opened = null;
+  let swipeHintDismissed = false;
+  let currentHintEl = null;
+
+  function enhanceRow(tr){
+    if (tr.dataset.mobileReady === '1') return;
+
+    const cells = tr.querySelectorAll('td');
+    if (cells.length < 7) return;
+
+    const pilarSel   = cells[0].querySelector('select[data-col="0"]');
+    const rasgoSel   = cells[1].querySelector('select[data-col="1"]');
+    const statInput  = cells[2].querySelector('input[data-col="2"]');
+    const taskInput  = cells[3].querySelector('input[data-col="3"]');
+    const diffSelect = cells[4].querySelector('select[data-col="4"]');
+    const feedbackBox= cells[5].querySelector('.feedback');
+
+    if (!taskInput || !diffSelect || !pilarSel || !rasgoSel || !statInput) return;
+
+    const td = document.createElement('td');
+    td.colSpan = tr.children.length || cells.length || 7;
+
+    const item = document.createElement('div');
+    item.className = 'item';
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    const btnModify  = makeAction('modify','🔁','Modificar', ()=> runAiForRow(tr,'replace'));
+    const btnImprove = makeAction('improve','🪄','Mejorar',   ()=> runAiForRow(tr,'improve'));
+    const btnDelete  = makeAction('del','🗑️','Eliminar',     ()=> deleteRow(tr));
+    actions.append(btnImprove, btnModify, btnDelete);
+
+    const slidable = document.createElement('div');
+    slidable.className = 'slidable shadow';
+
+    const mark = document.createElement('div');
+    mark.className = 'mark';
+
+    const content = document.createElement('div');
+    content.className = 'content';
+
+    const rowMain = document.createElement('div');
+    rowMain.className = 'row-main';
+
+    taskInput.classList.add('task-input');
+    taskInput.setAttribute('placeholder','Nueva task…');
+
+    const diffChip = document.createElement('button');
+    diffChip.type = 'button';
+    diffChip.className = 'diff-chip';
+    diffChip.title = 'Cambiar dificultad';
+    diffChip.innerHTML = '<span class="dot"></span><span class="label"></span>';
+
+    const more = document.createElement('button');
+    more.type = 'button';
+    more.className = 'more';
+    more.title = 'Mostrar columnas';
+    more.textContent = '⋯';
+
+    rowMain.append(taskInput, diffChip, more);
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+
+    const statLabel = createMeta('Stat', statInput);
+    const rasgoLabel = createMeta('Rasgo', rasgoSel);
+    const pilarLabel = createMeta('Pilar', pilarSel);
+
+    const feedbackWrap = document.createElement('div');
+    feedbackWrap.className = 'feedback';
+    if (feedbackBox) {
+      feedbackWrap.append(...feedbackBox.children);
+    }
+
+    const metaActions = document.createElement('div');
+    metaActions.className = 'meta-actions';
+    const aiImprove = makeMetaAction('🪄', 'Mejorar con IA', ()=> runAiForRow(tr,'improve'));
+    const aiReplace = makeMetaAction('🔁', 'Modificar con IA', ()=> runAiForRow(tr,'replace'));
+    const deleteBtn = makeMetaAction('🗑️', 'Eliminar fila', ()=> deleteRow(tr), true);
+    metaActions.append(aiImprove, aiReplace, deleteBtn);
+
+    meta.append(pilarLabel, rasgoLabel, statLabel, feedbackWrap, metaActions);
+
+    slidable.append(mark, content, actions);
+    content.append(rowMain, meta);
+
+    item.append(slidable);
+    td.append(item);
+
+    tr.innerHTML = '';
+    tr.append(td);
+    tr.dataset.mobileReady = '1';
+
+    const idx = Number(tr.dataset.index);
+    if (!Number.isNaN(idx) && typeof state !== 'undefined'){
+      if (state.aiUpdated && state.aiUpdated.has(idx)){
+        const mode = state.rows?.[idx]?.__aiMode === 'replace' ? 'replace' : 'improve';
+        item.classList.add(mode === 'replace' ? 'ai-modified' : 'ai-improved');
+      }
+    }
+
+    updateDiff(diffChip, diffSelect.value);
+    diffSelect.classList.add('sr-only');
+
+    function pushDiffToState(){
+      if (typeof state === 'undefined' || Number.isNaN(idx)) return;
+      if (!state.rows || !state.rows[idx]) return;
+      const v = (typeof normDiff === 'function') ? normDiff(diffSelect.value) : diffSelect.value;
+      if (state.rows[idx][4] !== v) {
+        state.rows[idx][4] = v;
+        if (typeof markDirty === 'function') markDirty();
+      }
+    }
+
+    diffChip.addEventListener('click', ()=>{
+      cycleDiff(diffSelect);
+      updateDiff(diffChip, diffSelect.value);
+      pushDiffToState();
+      diffSelect.dispatchEvent(new Event('input',  { bubbles:true }));
+      diffSelect.dispatchEvent(new Event('change', { bubbles:true }));
+    });
+
+    diffSelect.addEventListener('change', ()=>{
+      updateDiff(diffChip, diffSelect.value);
+      pushDiffToState();
+    });
+    diffSelect.addEventListener('input', ()=>{
+      updateDiff(diffChip, diffSelect.value);
+      pushDiffToState();
+    });
+
+    more.addEventListener('click', (e)=>{
+      e.preventDefault(); e.stopPropagation();
+      const willExpand = !item.classList.contains('expanded');
+      item.classList.toggle('expanded', willExpand);
+      if (willExpand) openRow(item, slidable, true);
+      else            closeRow(item, slidable);
+    });
+
+    makeSwipeable(item, slidable);
+  }
+
+  function makeAction(cls, icon, label, onClick){
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = `act ${cls}`;
+    b.setAttribute('aria-label', label);
+    b.innerHTML = `<span aria-hidden="true">${icon}</span><span class="sr-only">${label}</span>`;
+    b.addEventListener('click', (e)=>{
+      e.preventDefault();
+      e.stopPropagation();
+      closeAll();
+      onClick();
+    });
+    return b;
+  }
+
+  function makeMetaAction(icon, label, onClick, danger=false){
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `meta-btn${danger ? ' danger' : ''}`;
+    btn.innerHTML = `<span aria-hidden="true">${icon}</span><span>${label}</span>`;
+    btn.addEventListener('click', (e)=>{
+      e.preventDefault();
+      e.stopPropagation();
+      onClick();
+    });
+    return btn;
+  }
+
+  function createMeta(label, control){
+    const wrap = document.createElement('label');
+    wrap.textContent = label;
+    wrap.append(control);
+    return wrap;
+  }
+
+  function updateDiff(chip, value){
+    chip.dataset.v = value || '';
+    chip.querySelector('.label').textContent = value || '—';
+  }
+
+  function cycleDiff(select){
+    const opts = Array.from(select.options).map(o=>o.value).filter(Boolean);
+    if(!opts.length) return;
+    const idx = opts.indexOf(select.value);
+    const next = opts[(idx+1)%opts.length];
+    select.value = next;
+  }
+
+  function makeSwipeable(wrapper, slide){
+    const actions = wrapper.querySelector('.actions');
+    const max = () => actions ? actions.getBoundingClientRect().width + 12 : 0;
+
+    let startX = 0;
+    let currentX = 0;
+    let dragging = false;
+    let pointerId = null;
+
+    const start = (event) => {
+      if (dragging) return;
+      pointerId = event.pointerId;
+      dragging = true;
+      startX = event.clientX;
+      wrapper.classList.add('dragging');
+      slide.style.transition = 'none';
+      wrapper.classList.remove('swipe-hint');
+    };
+
+    const move = (event) => {
+      if (!dragging || event.pointerId !== pointerId) return;
+      currentX = event.clientX;
+      const dx = currentX - startX;
+      if (dx < 0) {
+        slide.style.transform = `translateX(${Math.max(dx, -max())}px)`;
+        if (!wrapper.classList.contains('row-open')) {
+          wrapper.classList.add('row-peek');
+        }
+      } else {
+        slide.style.transform = `translateX(${Math.min(dx, 0)}px)`;
+      }
+    };
+
+    const end = (event) => {
+      if (!dragging || event.pointerId !== pointerId) return;
+      dragging = false;
+      wrapper.classList.remove('dragging');
+      slide.style.transition = '';
+
+      const dx = currentX - startX;
+      const threshold = max() * 0.45;
+      if (dx < -threshold) {
+        openRow(wrapper, slide);
+      } else {
+        closeRow(wrapper, slide);
+      }
+      pointerId = null;
+    };
+
+    slide.addEventListener('pointerdown', start);
+    slide.addEventListener('pointermove', move);
+    slide.addEventListener('pointerup', end);
+    slide.addEventListener('pointercancel', end);
+    slide.addEventListener('pointerleave', end);
+  }
+
+  function openRow(wrapper, slide, viaMore=false){
+    closeOther(wrapper);
+    const actions = wrapper.querySelector('.actions');
+
+    if(viaMore){
+      slide.style.transform = 'translateX(0)';
+      wrapper.classList.add('expanded');
+    }else{
+      const width = actions?.getBoundingClientRect().width
+        || parseFloat(getComputedStyle(document.documentElement)
+             .getPropertyValue('--actionsw')) || 0;
+      slide.style.transform = `translateX(${-width - 12}px)`;
+      wrapper.classList.remove('expanded');
+    }
+
+    wrapper.classList.add('row-open');
+    wrapper.classList.remove('row-peek');
+    opened = wrapper;
+
+    if(wrapper === currentHintEl){
+      dismissHint();
+    }
+  }
+
+  function closeRow(wrapper, slide){
+    slide.style.transform = 'translateX(0)';
+    wrapper.classList.remove('row-open', 'row-peek');
+    wrapper.classList.remove('expanded');
+    if(opened === wrapper) opened = null;
+  }
+
+  function closeAll(){
+    if(!opened) return;
+    const slide = opened.querySelector('.slidable');
+    if(slide) closeRow(opened, slide);
+  }
+
+  function closeOther(wrapper){
+    if(!opened || opened === wrapper) return;
+    const slide = opened.querySelector('.slidable');
+    if(slide) closeRow(opened, slide);
+  }
+
+  document.addEventListener('pointerdown', (e)=>{
+    if(!opened) return;
+    if(opened.contains(e.target)) return;
+    const slide = opened.querySelector('.slidable');
+    if(slide) closeRow(opened, slide);
+  });
+
+  function armSwipeHint(){
+    if(currentHintEl && !currentHintEl.isConnected){
+      currentHintEl = null;
+    }
+    if(swipeHintDismissed) return;
+    const first = tbody.querySelector('tr:first-child .item');
+    if(!first || first === currentHintEl) return;
+    if(currentHintEl){
+      currentHintEl.classList.remove('swipe-hint');
+    }
+    currentHintEl = first;
+    first.classList.add('swipe-hint');
+    const stop = (ev)=>{
+      if(!currentHintEl) return;
+      if(ev && !currentHintEl.contains(ev.target)) return;
+      dismissHint();
+    };
+    currentHintEl.addEventListener('touchstart', stop, { once:true, capture:true });
+    currentHintEl.addEventListener('pointerdown', stop, { once:true, capture:true });
+  }
+
+  function dismissHint(){
+    if(currentHintEl){
+      currentHintEl.classList.remove('swipe-hint');
+    }
+    currentHintEl = null;
+    swipeHintDismissed = true;
+  }
+
+  function deleteRow(tr){
+    if(typeof state === 'undefined') return;
+    const idx = Number(tr.dataset.index);
+    if(Number.isNaN(idx)) return;
+    state.rows.splice(idx,1);
+
+    const next = new Set();
+    for(const i of state.aiUpdated){
+      if(i < idx) next.add(i);
+      else if(i > idx) next.add(i - 1);
+    }
+    state.aiUpdated = next;
+
+    markDirty();
+    render();
+  }
+
+  async function runAiForRow(tr, mode){
+    if(typeof state === 'undefined') return;
+    const idx = Number(tr.dataset.index);
+    if(Number.isNaN(idx)) return;
+    const row = state.rows[idx];
+    if(!row) return;
+
+    try{
+      aiLoading(true);
+      row.__aiMode = mode === 'replace' ? 'replace' : 'improve';
+      const batch = [[normPilar(row[0]||''), cleanRasgo(row[1]||''), (row[2]||''), (row[3]||''), normDiff(row[4]||''), mode]];
+      const results = await aiSendBatch(email, batch);
+      aiApplyResults([idx], results);
+      markDirty();
+      render();
+      toast(mode === 'improve' ? '🪄 Task mejorada con IA' : '🔁 Task modificada con IA');
+    }catch(err){
+      console.error(err);
+      toast('Error al usar IA: ' + err.message, false);
+    }finally{
+      aiLoading(false);
+    }
+  }
+}
+
+function registerShadowServiceWorker(){
+  if (!('serviceWorker' in navigator)) return;
+  const swUrl = new URL('../../sw.refactor.js', import.meta.url);
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register(swUrl, { scope: '/' })
+      .catch(err => console.error('[SW] registro falló', err));
+  });
+}
+
+function guardConfirmButton(){
+  const bbddPanel = document.querySelector('.bbdd-panel');
+  const confirmarBtn = document.getElementById('bbdd-confirm');
+  if (!bbddPanel || !confirmarBtn || typeof window.doConfirm !== 'function') {
+    return;
+  }
+
+  const confirmarOriginal = window.doConfirm;
+
+  const escudoDeGuardado = document.getElementById('saving-shield') ?? (() => {
+    const nuevoEscudo = document.createElement('div');
+    nuevoEscudo.id = 'saving-shield';
+    Object.assign(nuevoEscudo.style, {
+      position: 'absolute',
+      inset: '0',
+      zIndex: '70',
+      display: 'none',
+      background: 'transparent',
+      pointerEvents: 'auto',
+    });
+    bbddPanel.appendChild(nuevoEscudo);
+    return nuevoEscudo;
+  })();
+
+  const desactivarControlesDelPanel = () => {
+    bbddPanel.querySelectorAll('input, select, textarea, button').forEach(control => {
+      if (control === confirmarBtn) return;
+      if (!control.disabled) control.dataset.estabaActivo = '1';
+      control.disabled = true;
+    });
+  };
+
+  const restaurarControlesDelPanel = () => {
+    bbddPanel.querySelectorAll('[data-estaba-activo="1"]').forEach(control => {
+      control.disabled = false;
+      delete control.dataset.estabaActivo;
+    });
+  };
+
+  window.doConfirm = async function confirmarConEscudo() {
+    if (confirmarBtn.dataset.bloqueado === '1') return;
+    confirmarBtn.dataset.bloqueado = '1';
+
+    document.activeElement?.blur?.();
+
+    bbddPanel.classList.add('saving');
+    bbddPanel.setAttribute('aria-busy', 'true');
+    escudoDeGuardado.style.display = 'block';
+    desactivarControlesDelPanel();
+
+    try {
+      await confirmarOriginal.call(this);
+    } finally {
+      restaurarControlesDelPanel();
+      escudoDeGuardado.style.display = 'none';
+      bbddPanel.classList.remove('saving');
+      bbddPanel.removeAttribute('aria-busy');
+      delete confirmarBtn.dataset.bloqueado;
+    }
+  };
+}
+
+/* ====== Init ====== */
+async function init(){
+  if(!email){
+    alert("No se detectó tu email. Abrí esta página desde el Dashboard (menú → Editar Base).");
+    return;
+  }
+
+  detectMode();
+  setupAppbarSnap();
+
+  // Modo: modal o página
+  if (window.BBDD_MODE === "modal") {
+    openOverlay();
+  } else {
+    qs("#bbdd-overlay").classList.remove("hidden");
+  }
+
+  guardConfirmButton();
+
+  // ── Listeners UI ───────────────────────────────────────────────
+  qs("#bbdd-back").addEventListener("click", (e)=> {
+    e.preventDefault();
+
+    if (window.BBDD_MODE === "modal") {
+      closeOverlay();
+      return;
+    }
+
+    // En “page/web”: priorizar &back= si existe; si no, ir al dashboard con email
+    const u = new URL(location.href);
+    const back = u.searchParams.get("back");
+    if (back) {
+      location.href = decodeURIComponent(back);
+      return;
+    }
+
+    const dash = new URL(DASHBOARD_URL);
+    if (email) dash.searchParams.set("email", email);
+    location.href = dash.toString();
+  });
+
+  qs("#close-modal").addEventListener("click", closeOverlay);
+  qs("#bbdd-confirm").addEventListener("click", ()=> doConfirm().catch(e=>toast(e.message,false)));
+  qs("#add-row").addEventListener("click", ()=>{ state.rows.push(["","","","","",""]); markDirty(); render(); });
+  qs("#search").addEventListener("input", onFilter);
+
+  // Botón AI (opcional)
+  const aiBtn = document.getElementById("bbdd-ai");
+  if (aiBtn) {
+    aiBtn.addEventListener("click", () => {
+      aiRunForSelection().catch(e => toast(e.message, false));
+    });
+  }
+  // const aiBtn = document.getElementById("bbdd-ai");
+  // if (aiBtn) {
+  //   aiBtn.addEventListener("click", ()=>{
+  //     const marcadas = state.rows.filter(r => r[5]==="improve" || r[5]==="replace");
+  //     if(!marcadas.length){
+  //       alert("Seleccioná al menos una task con feedback🪄 o 🔁");
+  //       return;
+  //     }
+  //     console.log("Tasks seleccionadas para AI:", marcadas);
+  //   });
+  // }
+
+  // Cerrar con ESC
+  document.addEventListener("keydown", (e)=>{
+    if (e.key === "Escape") {
+      const doClose = () => {
+        if (window.BBDD_MODE === "modal") closeOverlay();
+        else history.back();
+      };
+      if (state.dirty) {
+        if (confirm("Tenés cambios sin guardar. ¿Cerrar igualmente?")) doClose();
+      } else {
+        doClose();
+      }
+    }
+  });
+
+  // Atajo: Ctrl/⌘+V para pegar filas (si no estás editando un campo)
+  document.addEventListener("keydown", async (e)=>{
+    const isPaste = (e.key.toLowerCase() === "v") && (e.ctrlKey || e.metaKey);
+    if (!isPaste) return;
+
+    const tag = (document.activeElement?.tagName || "").toLowerCase();
+    const isEditingField = ["input","textarea","select"].includes(tag);
+    if (isEditingField) return; // dejar pegar dentro del campo
+
+    e.preventDefault();
+    try { await pasteFromClipboard(); }
+    catch { toast("No pude leer el portapapeles. Probá habilitar permisos.", false); }
+  });
+
+  // ── Carga de datos ─────────────────────────────────────────────
+  setTableLoading(true);
+  try{
+    const { rows } = await apiGetBBDD(email);
+
+    // Filtro estricto: conservar solo filas con Tasks (col 3) no vacía
+    const fetched = (rows || []).filter(r => (r?.[3] ?? "").toString().trim() !== "");
+
+    // Extender con slot de feedback
+    state.rows = fetched.map(r => [ r[0]||"", r[1]||"", r[2]||"", r[3]||"", r[4]||"", "" ]);
+
+    // Hash calculado sobre lo realmente renderizado
+    state.origHash = hashRows(fetched);
+
+    render();
+    setupMobileEnhancements();
+  } catch(err){
+    toast("Error cargando BBDD: " + err.message, false);
+  } finally {
+    setTableLoading(false);
+  }
+}
+
+// Bootstrap
+if (document.readyState !== "loading") init();
+else document.addEventListener("DOMContentLoaded", init);
+
+registerShadowServiceWorker();
+
+/* ====== Exponer helper para abrir modal desde el dashboard ====== */
+window.openBBDD = function(emailParam){
+  if (emailParam) localStorage.setItem("gj_email", emailParam);
+  window.BBDD_MODE = "modal";
+  init();
+};

--- a/refactor/manifest.refactor.json
+++ b/refactor/manifest.refactor.json
@@ -1,0 +1,16 @@
+{
+  "name": "Gamification Journey",
+  "short_name": "GJ",
+  "description": "Tu dashboard gamificado como app.",
+  "start_url": "./loginv2.html",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0b0b10",
+  "theme_color": "#7d3cff",
+  "icons": [
+    { "src": "./icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "./icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "./icons/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable any" }
+  ]
+}

--- a/refactor/sw.refactor.js
+++ b/refactor/sw.refactor.js
@@ -1,0 +1,81 @@
+// Refactor: registrá manualmente este SW con `navigator.serviceWorker.register('/refactor/sw.refactor.js', { scope: '/' })`
+// Cambiá la versión para invalidar caché cuando actualices assets
+const CACHE = 'gj-v2';
+
+// Precaché de la “app shell”
+const APP_SHELL = [
+  './loginv2.html',
+  './dashboardv3.html',
+  './index-bbdd.html',
+  './offline.html',
+
+  // CSS
+  './css/loginv2.css',
+  './css/dashboardv3.css',
+  './css/bbdd.css',
+
+  // JS
+  './js/loginv2.js',
+  './js/dashboardv3.js',
+  './js/scheduler-controller.js',
+  './js/scheduler-modal.js',
+  './js/scheduler-api.js',
+  './js/bbdd.js',
+
+  // Íconos PWA
+  './icons/icon-192.png',
+  './icons/icon-512.png',
+  './icons/maskable-512.png'
+];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open(CACHE).then(c => c.addAll(APP_SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+// Estrategia:
+// - HTML → network-first, fallback a caché y luego offline.html
+// - Assets (css/js/img locales) → stale-while-revalidate
+self.addEventListener('fetch', (e) => {
+  const req = e.request;
+  const url = new URL(req.url);
+
+  // Controlamos solo recursos del mismo origen (tu repo)
+  if (url.origin !== self.location.origin) return;
+
+  const isHTML = req.mode === 'navigate' || (req.headers.get('accept') || '').includes('text/html');
+
+  if (isHTML) {
+    e.respondWith(
+      fetch(req).then(res => {
+        const copy = res.clone();
+        caches.open(CACHE).then(c => c.put(req, copy));
+        return res;
+      }).catch(async () => {
+        const cached = await caches.match(req);
+        return cached || caches.match('./offline.html');
+      })
+    );
+    return;
+  }
+
+  // Assets locales
+  e.respondWith(
+    caches.match(req).then(cached => {
+      const fetchProm = fetch(req).then(res => {
+        caches.open(CACHE).then(c => c.put(req, res.clone()));
+        return res;
+      }).catch(() => cached);
+      return cached || fetchProm;
+    })
+  );
+});

--- a/refactor/views/index-bbdd.refactor.html
+++ b/refactor/views/index-bbdd.refactor.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link rel="manifest" href="../../manifest.refactor.json">
+  <meta name="theme-color" content="#7d3cff">
+  <title>Edicion de Base de Datos</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/base.css" />
+  <link rel="stylesheet" href="../css/bbdd.css" />
+
+</head>
+<body>
+  <!-- ===== OVERLAY PRINCIPAL ===== -->
+  <div id="bbdd-overlay" class="bbdd-overlay hidden">
+    <div class="bbdd-panel">
+      <!-- ===== APPBAR + HERRAMIENTAS ===== -->
+      <header class="appbar">
+        <div class="top-row">
+          <div class="primary">
+            <button class="btn icon" id="bbdd-back" title="Volver">⟵</button>
+            <div class="title-wrap">
+              <div class="title">Conf BBDD &amp; Daily Quest</div>
+              <div class="sub">Lista compacta • Swipe a la izquierda para acciones • Tap en dificultad para ciclarla</div>
+            </div>
+          </div>
+          <div class="row-actions">
+            <button id="bbdd-confirm" class="btn primary">Confirmar cambios ✓</button>
+          </div>
+        </div>
+
+        <details class="guide" open>
+          <summary>📌 Cómo escribir buenas Tasks + usar IA</summary>
+          <ul>
+            <li>Completables en un día, claras y medibles.</li>
+            <li>Evitá vaguedades. Mejor: “Preparar comida saludable” / “Meditar 10’”.</li>
+            <li>Deslizá y usá <strong>Mejorar</strong> o <strong>Modificar</strong> con IA para afinar la task.</li>
+          </ul>
+        </details>
+
+        <div class="tools">
+          <div class="left-tools">
+            <button id="add-row" class="btn">＋ Fila</button>
+            <span id="dirty-indicator" class="indicator hidden">● Cambios sin guardar</span>
+          </div>
+          <div class="field" style="flex:1">
+            <span aria-hidden="true">🔎</span>
+            <input id="search" type="search" placeholder="Filtrar tareas…" autocomplete="off" />
+          </div>
+          <button id="bbdd-ai" class="btn" title="Generar con IA">✨ AI (Beta)<span id="ai-sparkle"></span></button>
+        </div>
+
+        <div class="thead">
+          <span class="label">Task</span>
+          <button id="add-row-dup" class="btn add" type="button">＋</button>
+        </div>
+      </header>
+
+      <!-- ===== TABLA DE TAREAS ===== -->
+      <main>
+        <section id="table-wrap">
+          <div id="table-spinner" aria-live="polite" aria-busy="true">
+            <span class="ring" aria-hidden="true"></span>
+            <span class="txt">Cargando tus tareas…</span>
+          </div>
+          <div id="ai-overlay" role="status" aria-live="polite">
+            <span class="spark">✨</span>
+            <span>Generando tareas con IA…</span>
+          </div>
+          <table id="bbdd-table" aria-label="Tabla de tareas">
+            <colgroup>
+              <col class="col-pilar" />
+              <col class="col-rasgo" />
+              <col class="col-stat" />
+              <col class="col-task" />
+              <col class="col-dificultad" />
+              <col class="col-feedback" />
+              <col class="col-eliminar" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th>Pilar</th>
+                <th>Rasgo</th>
+                <th>Stat</th>
+                <th>Task</th>
+                <th>Dificultad</th>
+                <th>Feedback</th>
+                <th>Eliminar</th>
+              </tr>
+            </thead>
+            <tbody id="bbdd-tbody"></tbody>
+          </table>
+        </section>
+      </main>
+
+      <!-- ===== FOOTER PERSISTENTE ===== -->
+      <footer class="bbdd-footer">
+        <small id="status-msg"></small>
+        <button id="close-modal" class="btn">Cerrar</button>
+      </footer>
+    </div>
+  </div>
+
+
+  <!-- Hook JS: módulo BBDD controla tabla, IA y confirmación -->
+  <script type="module" src="../js/features/bbdd.js"></script>
+
+</body>
+</html>

--- a/refactor/views/offline.refactor.html
+++ b/refactor/views/offline.refactor.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Sin conexión — GJ</title>
+  <link rel="manifest" href="../../manifest.refactor.json">
+  <meta name="theme-color" content="#7d3cff">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/base.css">
+  <link rel="stylesheet" href="../css/bbdd.css">
+</head>
+<body class="offline-body">
+  <!-- ===== MENSAJE OFFLINE ===== -->
+  <main class="offline-card" role="status" aria-live="polite">
+    <h1>Estás offline</h1>
+    <p>Podés abrir <a href="../../dashboardv3.html">tu Dashboard</a> en modo lectura si ya se visitó antes. La edición de BBDD y envíos requieren conexión.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add refactored BBDD editor and offline fallback views with modular CSS and shared tokens
- port API, drag & drop, and AI UI logic into a module while exposing refactor manifest/service worker
- document how to load the refactor assets for local testing without touching production files

## Testing
- python3 -m http.server 8000 (manually opened refactor/views/index-bbdd.refactor.html and offline.refactor.html)


------
https://chatgpt.com/codex/tasks/task_e_68debf4141888322a4e67c215bd6fef3