### PR TITLE
Document refactor view map and update guidelines

### DIFF
--- a/refactor/CONTRIBUTING.refactor.md
+++ b/refactor/CONTRIBUTING.refactor.md
@@ -3,6 +3,10 @@
 1. **No toques los originales.** Toda mejora vive dentro de `refactor/` con el mismo nombre + `.refactor` si es una vista.
 2. **Mantén los comentarios amigables.** Explica qué hace cada bloque y por qué, evitando tecnicismos innecesarios.
 3. **Respeta la estructura.** CSS en `refactor/css`, JS en `refactor/js`, HTML en `refactor/views`.
-4. **Misiones por lote.** Antes de comenzar una tarea, agrega notas en este archivo o en DOCUMENTATION si surgen dudas.
-5. **Pruebas manuales.** Al terminar, abre la vista en el navegador y sigue el flujo original para evitar regresiones.
-6. **TODOs documentados.** Si encuentras algo riesgoso, deja `// TODO:` explicando la mejora propuesta sin implementarla.
+4. **Documenta el módulo.** Cada archivo JS necesita encabezado con propósito, API pública, dependencias, efectos secundarios y notas de accesibilidad.
+5. **Patrón `CONFIG + state`.** Los features nuevos siguen la dupla `const CONFIG = {…}` / `const state = {…}` para agrupar endpoints y cachés. Si un valor se comparte, muévelo a `utils/constants.js`.
+6. **Secciones con `// =====`**. Divide bloques largos (helpers, eventos, boot) usando el formato `// ===== [Nombre] =====` para ubicar rápidamente cambios.
+7. **Registra inicialización segura.** Usa `document.addEventListener('DOMContentLoaded', ...)` o `init(root)` para no romper al abrir el HTML directo.
+8. **Pruebas manuales.** Al terminar, abre la vista en el navegador y sigue el flujo original para evitar regresiones. Deja constancia en el PR de los pasos ejecutados.
+9. **TODOs priorizados.** Si detectas un riesgo, anótalo en la sección "Backlog priorizado" de `DOCUMENTATION.refactor.md` con etiqueta P0/P1/P2 y marca el punto exacto en el código con `// TODO:` si aplica.
+10. **PWA y assets.** Si modificas el login o sus dependencias, valida también el `service worker` para que los assets refactorizados se precachen correctamente.

--- a/refactor/CONTRIBUTING.refactor.md
+++ b/refactor/CONTRIBUTING.refactor.md
@@ -5,8 +5,9 @@
 3. **Respeta la estructura.** CSS en `refactor/css`, JS en `refactor/js`, HTML en `refactor/views`.
 4. **Documenta el módulo.** Cada archivo JS necesita encabezado con propósito, API pública, dependencias, efectos secundarios y notas de accesibilidad.
 5. **Patrón `CONFIG + state`.** Los features nuevos siguen la dupla `const CONFIG = {…}` / `const state = {…}` para agrupar endpoints y cachés. Si un valor se comparte, muévelo a `utils/constants.js`.
-6. **Secciones con `// =====`**. Divide bloques largos (helpers, eventos, boot) usando el formato `// ===== [Nombre] =====` para ubicar rápidamente cambios.
+6. **Secciones con `// =====`.** Divide bloques largos (helpers, eventos, boot) usando el formato `// ===== [Nombre] =====` para ubicar rápidamente cambios.
 7. **Registra inicialización segura.** Usa `document.addEventListener('DOMContentLoaded', ...)` o `init(root)` para no romper al abrir el HTML directo.
 8. **Pruebas manuales.** Al terminar, abre la vista en el navegador y sigue el flujo original para evitar regresiones. Deja constancia en el PR de los pasos ejecutados.
 9. **TODOs priorizados.** Si detectas un riesgo, anótalo en la sección "Backlog priorizado" de `DOCUMENTATION.refactor.md` con etiqueta P0/P1/P2 y marca el punto exacto en el código con `// TODO:` si aplica.
 10. **PWA y assets.** Si modificas el login o sus dependencias, valida también el `service worker` para que los assets refactorizados se precachen correctamente.
+11. **Conflictos de merge.** Cuando sincronices con `main`, resuelve conflictos editando el archivo completo (sin dejar marcadores `<<<<<<<`) y vuelve a correr la revisión manual de vistas afectadas.

--- a/refactor/DOCUMENTATION.refactor.md
+++ b/refactor/DOCUMENTATION.refactor.md
@@ -1,16 +1,48 @@
-# Mapa inicial de la carpeta `refactor/`
+# Guía final de la carpeta `refactor/`
 
 > Esta guía explica cómo navegar la "carpeta sombra" sin modificar los archivos originales.
 
-## Vistas
-- `views/indexv2.refactor.html` — Landing principal. Usa `css/stylesv3.css` para visuales y `js/features/landing.js` para el carrusel accesible.
-- `views/loginv2.refactor.html` — Portal de acceso. Usa `css/layout.css` y el módulo `js/features/login.js`.
+## Mapa final · Vista → módulos → estilos → endpoints
 
-## Utilidades JS
-- `js/utils/dom.js` — Selectores seguros, escucha de eventos y helpers para manipular atributos sin repetir código.
-- `js/utils/net.js` — Capa muy simple sobre `fetch` para llamadas JSON con timeouts.
-- `js/utils/a11y.js` — Rutinas para foco, anuncios en `aria-live` y ayuda de accesibilidad.
-- `js/utils/constants.js` — Endpoints, claves de almacenamiento y flags compartidos.
+### `views/indexv2.refactor.html` — Landing principal
+- **JS principal:** `../js/features/landing.js` → usa `utils/dom` para selectores seguros y `utils/a11y` para anuncios accesibles.
+- **Hojas de estilo:** `../css/base.css`, `../css/stylesv3.css`.
+- **Endpoints / rutas externas:** no invoca APIs; sólo enlaza a `formsintrov3.html`, `signupv2.html`, `loginv2.html` y assets alojados en i.ibb.co.
+
+### `views/loginv2.refactor.html` — Portal de acceso
+- **JS principal:** `../js/features/login.js` → depende de `utils/dom`, `utils/a11y` y `utils/constants`.
+- **Hojas de estilo:** `../css/base.css`, `../css/layout.css`.
+- **Endpoints / rutas:**
+  - `CHECK_ENDPOINT` (`utils/constants`) para conocer el estado del bundle.
+  - `WORKER_BASE` (`utils/constants`) con `/bundle` para prefetchear datos.
+  - `OLD_WEBAPP_URL` (`utils/constants`) como fallback legacy.
+  - `REFRESH_ENDPOINT` (`utils/constants`) para despertar al worker de refresco.
+  - `DASHBOARD_ROUTE` (`utils/constants`) para redirigir cuando todo está listo.
+  - Registra `../../sw.js` (scope `../../`) para compatibilidad con la PWA original.
+
+### `views/signupv2.refactor.html` — Alta de usuarios
+- **JS principal:** `../js/features/signupv2.js` → depende de `utils/dom` y `utils/net`.
+- **Hojas de estilo:** `../css/base.css`, `../css/signupv2.css`.
+- **Endpoints / rutas:** definidos dentro de `CONFIG` del módulo.
+  - `formAction`: Google Form que recibe la data cruda.
+  - `statusEndpoint`: Apps Script que informa si la base fue procesada.
+  - `imgbbEndpoint`: servicio de carga de avatares.
+  - `formPublicUrl`: enlace público al formulario detallado.
+  - `loginUrl`: reutiliza `loginv2.html` para volver al flujo principal.
+
+### `views/formsintrov3.refactor.html` — Wizard gamificado
+- **JS principal:** `../js/features/formsintrov2.js` → usa `utils/dom` (selectores, delegación) y `utils/net` (POST JSON).
+- **Hojas de estilo:** `../css/base.css`, `../css/formsintrov2.css`.
+- **Endpoints / rutas:**
+  - `WORKER_URL`: worker de onboarding que guarda el payload completo.
+  - `REDIRECT_URL`: envía al usuario a `loginv2.html?await=1` después del envío.
+  - `https://rfullivarri.github.io/gamificationweblanding/indexv2.html`: fallback manual del HUD para reiniciar el recorrido.
+
+## Utilidades JS disponibles
+- `js/utils/dom.js` — Selectores seguros, delegación de eventos, helpers de foco y serialización de formularios.
+- `js/utils/net.js` — Wrapper de `fetch` con timeout, POST JSON y reintentos.
+- `js/utils/a11y.js` — Helpers para trap focus y anuncios aria-live.
+- `js/utils/constants.js` — Endpoints compartidos por el flujo de login.
 
 ## Cómo probar una vista refactorizada
 1. Abrí el archivo `.refactor.html` directo en el navegador (doble clic o `Live Server`).
@@ -18,9 +50,19 @@
 3. Revisá la consola: no debe haber errores nuevos. Si aparece alguno, anotarlo en TODO.
 4. Compará visualmente con la versión original para asegurar que la UI/UX no cambió.
 
-## Convenciones
+## Convenciones de código
 - Comentarios con tono sencillo, como si se lo explicáramos a alguien de 5 años.
 - Archivos CSS con encabezado `/* ==========================================================================`.
 - Módulos JS con encabezado detallando propósito, API pública, dependencias y notas de accesibilidad.
+- Secciones largas en JS separadas por comentarios `// ===== [Bloque] =====` para ubicar rápidamente el código.
 
-Más vistas y módulos se irán sumando en los siguientes lotes.
+## Backlog priorizado
+- **P0 — Service worker dedicado:** el login refactor registra `sw.js`, que sigue precacheando assets viejos (`css/loginv2.css`) y genera 404 en las vistas refactorizadas. Crear `sw.refactor.js` con un manifiesto propio y actualizar `wireServiceWorker()` para usarlo.
+- **P1 — Centralizar endpoints compartidos:** `signupv2.js` y `formsintrov2.js` conservan URLs incrustadas. Moverlas a `utils/constants.js` (o un `config.refactor.json`) para versionarlas sin tocar cada módulo.
+- **P2 — Dividir el wizard en submódulos:** `formsintrov2.js` supera las 800 líneas. Separar listas estáticas, helpers de XP y capa de envío en archivos individuales para facilitar pruebas y mantenibilidad.
+
+## Resumen ejecutivo del refactor
+- Vistas críticas (`landing`, `login`, `signup`, `wizard`) migradas a HTML modular con CSS/JS dedicados en `refactor/` sin tocar los originales.
+- Utilidades compartidas (`dom`, `net`, `a11y`, `constants`) homogenizan la forma de seleccionar nodos, lanzar fetchs y anunciar estados accesibles.
+- Flujo de autenticación replica la lógica legacy (polling, modales, PWA) pero con módulos claros y configuraciones centralizadas.
+- Formularios (`signup`, `wizard`) envían datos a los endpoints productivos preservando IDs y timers, listos para pruebas A/B antes de reemplazar la versión pública.

--- a/refactor/DOCUMENTATION.refactor.md
+++ b/refactor/DOCUMENTATION.refactor.md
@@ -5,23 +5,26 @@
 ## Mapa final · Vista → módulos → estilos → endpoints
 
 ### `views/indexv2.refactor.html` — Landing principal
-- **JS principal:** `../js/features/landing.js` → usa `utils/dom` para selectores seguros y `utils/a11y` para anuncios accesibles.
+- **JS principal:** `../js/features/landing.js`.
+- **Utilidades compartidas:** `utils/dom` para selectores seguros, `utils/a11y` para anuncios accesibles.
 - **Hojas de estilo:** `../css/base.css`, `../css/stylesv3.css`.
-- **Endpoints / rutas externas:** no invoca APIs; sólo enlaza a `formsintrov3.html`, `signupv2.html`, `loginv2.html` y assets alojados en i.ibb.co.
+- **Endpoints / rutas externas:** no invoca APIs; enlaza a `formsintrov3.html`, `signupv2.html`, `loginv2.html` y a assets alojados en `i.ibb.co`.
 
 ### `views/loginv2.refactor.html` — Portal de acceso
-- **JS principal:** `../js/features/login.js` → depende de `utils/dom`, `utils/a11y` y `utils/constants`.
+- **JS principal:** `../js/features/login.js`.
+- **Utilidades compartidas:** `utils/dom`, `utils/a11y`, `utils/constants`.
 - **Hojas de estilo:** `../css/base.css`, `../css/layout.css`.
 - **Endpoints / rutas:**
   - `CHECK_ENDPOINT` (`utils/constants`) para conocer el estado del bundle.
-  - `WORKER_BASE` (`utils/constants`) con `/bundle` para prefetchear datos.
+  - `WORKER_BASE` (`utils/constants`) con `/bundle` para precargar datos.
   - `OLD_WEBAPP_URL` (`utils/constants`) como fallback legacy.
   - `REFRESH_ENDPOINT` (`utils/constants`) para despertar al worker de refresco.
   - `DASHBOARD_ROUTE` (`utils/constants`) para redirigir cuando todo está listo.
   - Registra `../../sw.js` (scope `../../`) para compatibilidad con la PWA original.
 
 ### `views/signupv2.refactor.html` — Alta de usuarios
-- **JS principal:** `../js/features/signupv2.js` → depende de `utils/dom` y `utils/net`.
+- **JS principal:** `../js/features/signupv2.js`.
+- **Utilidades compartidas:** `utils/dom`, `utils/net`.
 - **Hojas de estilo:** `../css/base.css`, `../css/signupv2.css`.
 - **Endpoints / rutas:** definidos dentro de `CONFIG` del módulo.
   - `formAction`: Google Form que recibe la data cruda.
@@ -31,7 +34,8 @@
   - `loginUrl`: reutiliza `loginv2.html` para volver al flujo principal.
 
 ### `views/formsintrov3.refactor.html` — Wizard gamificado
-- **JS principal:** `../js/features/formsintrov2.js` → usa `utils/dom` (selectores, delegación) y `utils/net` (POST JSON).
+- **JS principal:** `../js/features/formsintrov2.js`.
+- **Utilidades compartidas:** `utils/dom` (selectores, delegación) y `utils/net` (POST JSON, reintentos).
 - **Hojas de estilo:** `../css/base.css`, `../css/formsintrov2.css`.
 - **Endpoints / rutas:**
   - `WORKER_URL`: worker de onboarding que guarda el payload completo.
@@ -45,10 +49,10 @@
 - `js/utils/constants.js` — Endpoints compartidos por el flujo de login.
 
 ## Cómo probar una vista refactorizada
-1. Abrí el archivo `.refactor.html` directo en el navegador (doble clic o `Live Server`).
-2. Verificá que los enlaces sigan apuntando a las rutas originales (`signupv2.html`, `dashboardv3.html`, etc.).
-3. Revisá la consola: no debe haber errores nuevos. Si aparece alguno, anotarlo en TODO.
-4. Compará visualmente con la versión original para asegurar que la UI/UX no cambió.
+1. Abre el archivo `.refactor.html` directo en el navegador (doble clic o `Live Server`).
+2. Verifica que los enlaces sigan apuntando a las rutas originales (`signupv2.html`, `dashboardv3.html`, etc.).
+3. Revisa la consola: no debe haber errores nuevos. Si aparece alguno, anótalo en TODO.
+4. Compara visualmente con la versión original para asegurar que la UI/UX no cambió.
 
 ## Convenciones de código
 - Comentarios con tono sencillo, como si se lo explicáramos a alguien de 5 años.


### PR DESCRIPTION
## Summary
- document the final view → module → style → endpoint map and capture the prioritized backlog and executive summary
- expand contributing guidance with module documentation, CONFIG/state usage, manual regression and PWA validation steps

## Testing
- manual regression: opened indexv2.refactor.html, loginv2.refactor.html, signupv2.refactor.html, formsintrov3.refactor.html in browser

------
https://chatgpt.com/codex/tasks/task_e_68debf4716988322a5384b7bd91e92af