### PR TITLE
Refine onboarding helpers and polling

### DIFF
--- a/refactor/css/formsintrov2.css
+++ b/refactor/css/formsintrov2.css
@@ -38,6 +38,12 @@ body {
   padding-top: calc(var(--hudH) + 10px);
 }
 
+/* ===== [Intro: formulario inline para el email] =====
+   Usamos display: contents para no alterar el layout original. */
+.intro-form {
+  display: contents;
+}
+
 /* ===== [HUD: barra superior con progreso] ===== */
 .hud {
   position: fixed;

--- a/refactor/js/utils/net.js
+++ b/refactor/js/utils/net.js
@@ -1,7 +1,8 @@
 /**
  * Módulo: NetUtils
  * Propósito: envolver fetch con defaults seguros y fáciles de leer.
- * API pública: fetchJson(url, options), postJson(url, body, options), withTimeout(promise, ms)
+ * API pública: fetchJson(url, options), postJson(url, body, options), withTimeout(promise, ms),
+ *             retryOperation(fn, config), createPoller(task, config), fetchJsonWithRetry(url, config)
  * Dependencias: ninguna.
  * Side-effects: solo llamadas a fetch.
  * Errores esperados: timeouts o respuestas no JSON → se reportan en consola.
@@ -12,6 +13,28 @@ const DEFAULT_TIMEOUT_MS = 15000;
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * ===== [NetUtils: reintentar operaciones asíncronas] =====
+ * Ejecuta la callback varias veces; ideal para peticiones inestables.
+ */
+export async function retryOperation(operation, options = {}) {
+  const { retries = 2, retryDelay = 600 } = options;
+  let attempt = 0;
+  let lastError = null;
+  while (attempt <= retries) {
+    try {
+      return await operation(attempt);
+    } catch (error) {
+      lastError = error;
+      if (attempt === retries) break;
+      const delayMs = typeof retryDelay === 'function' ? retryDelay(attempt) : retryDelay * (attempt + 1);
+      await delay(delayMs);
+    }
+    attempt += 1;
+  }
+  throw lastError || new Error('[NetUtils] retryOperation agotó los intentos');
 }
 
 /**
@@ -77,17 +100,46 @@ export async function postJson(url, body, options = {}) {
  */
 export async function fetchJsonWithRetry(url, config = {}) {
   const { retries = 2, retryDelay = 600, fetchOptions = {} } = config;
-  let attempt = 0;
-  let lastError = null;
-  while (attempt <= retries) {
+  return retryOperation(() => fetchJson(url, fetchOptions), { retries, retryDelay });
+}
+
+/**
+ * ===== [NetUtils: creador de pollers] =====
+ * Devuelve un pequeño controlador para repetir una tarea cada cierto tiempo.
+ */
+export function createPoller(task, options = {}) {
+  const { interval = 1000, immediate = false, onError = () => {} } = options;
+  let timer = null;
+
+  const runTask = async () => {
     try {
-      return await fetchJson(url, fetchOptions);
+      const shouldStop = await task();
+      if (shouldStop === true) {
+        stop();
+      }
     } catch (error) {
-      lastError = error;
-      if (attempt === retries) break;
-      await delay(retryDelay * (attempt + 1));
+      onError(error);
     }
-    attempt += 1;
+  };
+
+  function start() {
+    stop();
+    if (immediate) {
+      runTask();
+    }
+    timer = setInterval(runTask, interval);
   }
-  throw lastError || new Error('[NetUtils] fetchJsonWithRetry agotó los intentos');
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function isRunning() {
+    return timer !== null;
+  }
+
+  return { start, stop, isRunning };
 }

--- a/refactor/views/formsintrov3.refactor.html
+++ b/refactor/views/formsintrov3.refactor.html
@@ -49,26 +49,29 @@
           <h2>Cap. 0 — El Despertar</h2>
           <p>Respirá. Hoy enciendes tu sistema de mejora. Te voy guiando para equilibrar <strong>Cuerpo, Mente y Alma</strong> con pasos simples.</p>
           <p><strong>Cómo funciona:</strong> por cada pregunta que completes vas a ir sumando puntos de experiencia <strong>(XP)</strong>. Algunas valen <em>+21 XP</em> (respuestas escritas o clave de modo) y otras <em>+13 XP</em> (selecciones).</p>
-          <div class="field" style="margin:12px 0">
-            <label for="emailInput">Tu correo (obligatorio)</label>
-            <input
-              id="emailInput"
-              name="email"
-              type="email"
-              placeholder="tu@email.com"
-              autocomplete="email"
-              autocapitalize="none"
-              spellcheck="false"
-              inputmode="email"
-              enterkeyhint="go"
-              required
-            />
-            <small style="color:#aab7ff">Lo usamos para crear tu tablero y guardar tu progreso.</small>
-          </div>
-          <div class="nav">
-            <button class="btn secondary" id="backIntroDisabled" disabled>—</button>
-            <button class="btn" id="goModes" disabled>Comenzar</button>
-          </div>
+          <!-- Formulario compacto solo para el email, permite Enter y serialización compartida -->
+          <form id="introForm" class="intro-form" novalidate>
+            <div class="field" style="margin:12px 0">
+              <label for="emailInput">Tu correo (obligatorio)</label>
+              <input
+                id="emailInput"
+                name="email"
+                type="email"
+                placeholder="tu@email.com"
+                autocomplete="email"
+                autocapitalize="none"
+                spellcheck="false"
+                inputmode="email"
+                enterkeyhint="go"
+                required
+              />
+              <small style="color:#aab7ff">Lo usamos para crear tu tablero y guardar tu progreso.</small>
+            </div>
+            <div class="nav">
+              <button class="btn secondary" id="backIntroDisabled" type="button" disabled>—</button>
+              <button class="btn" id="goModes" type="submit" disabled>Comenzar</button>
+            </div>
+          </form>
         </div>
         <figure class="pic">
           <img src="https://i.ibb.co/1GdbMQ1f/7e5cbb24-ebfe-4b0f-bbae-bddc1b66451a.jpg" alt="Intro">


### PR DESCRIPTION
## Summary
- wrap the intro email step in a real form inside formsintrov3 and expose display:contents styling to keep layout identical
- teach the onboarding wizard to use shared serializeForm data plus retryOperation when posting to the worker
- extend net utils with retry/poller helpers and switch the signup module to the shared poller for status checks

## Testing
- browser_container.run_playwright_script (signupv2/formsintrov3 smoke)

------
https://chatgpt.com/codex/tasks/task_e_68dec1f5d3a083229ae340c31e04452d