### PR TITLE
Fix refactor navigation previews and login fallback

### DIFF
--- a/refactor/js/dashboardv3.js
+++ b/refactor/js/dashboardv3.js
@@ -28,6 +28,7 @@ import {
   EVENT_NAMES,
   STORAGE_KEYS,
 } from './utils/constants.js';
+import { patchPreviewLinks } from './utils/dom.js';
 import PanelRachas from './features/panel-rachas.js';
 import { GJPopups } from './features/popups.js';
 import NotiClient from './features/noti-client.js';
@@ -240,6 +241,12 @@ async function loadDataFromCacheOrWebApp(email) {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
+  patchPreviewLinks({
+    'indexv2.html': 'indexv2.refactor.html',
+    'dashboardv3.html': 'dashboardv3.refactor.html',
+    'gamificationweblanding/index-bbdd.html': 'index-bbdd.refactor.html',
+  });
+
   // Spinner
   const overlay = document.getElementById("spinner-overlay");
   const showSpinner = () => overlay && (overlay.style.display = "flex");

--- a/refactor/js/features/landing.js
+++ b/refactor/js/features/landing.js
@@ -8,7 +8,7 @@
  * Notas de accesibilidad: actualiza aria-selected y responde a teclas.
  */
 
-import { byId, qsa, on } from '../utils/dom.js';
+import { byId, qsa, on, patchPreviewLinks } from '../utils/dom.js';
 import { announce } from '../utils/a11y.js';
 
 const AUTOPLAY_INTERVAL_MS = 4000;
@@ -89,6 +89,14 @@ function createCarousel(root) {
 }
 
 export function init(root = document) {
+  patchPreviewLinks({
+    'indexv2.html': 'indexv2.refactor.html',
+    'loginv2.html': 'loginv2.refactor.html',
+    'signupv2.html': 'signupv2.refactor.html',
+    'formsintrov3.html': 'formsintrov3.refactor.html',
+    'dashboardv3.html': 'dashboardv3.refactor.html',
+  }, root);
+
   const slider = createCarousel(byId('testi-slider'));
   return {
     teardown() {

--- a/refactor/js/features/login.js
+++ b/refactor/js/features/login.js
@@ -14,6 +14,7 @@ import {
   setHTML,
   toggleHidden,
   focusFirstInteractive,
+  patchPreviewLinks,
 } from '../utils/dom.js';
 import { announce, trapFocus, releaseFocus } from '../utils/a11y.js';
 import {
@@ -302,7 +303,10 @@ async function handleSubmit(event) {
     startPolling();
   } catch (error) {
     console.error('[Login] Error revisando el estado', error);
-    setStatus('Ups, algo falló. Intentá de nuevo en unos segundos.');
+    setStatus('Está lento. Te muestro los pasos y seguimos chequeando…');
+    hideLogin();
+    showModal(SELECTORS.awaitModal);
+    startPolling();
   } finally {
     if (goBtn) {
       goBtn.disabled = false;
@@ -321,7 +325,7 @@ function wireModalActions() {
     setStatus('Listo para intentar de nuevo.');
   });
 
-  const retry = byId(SELECTORS.retry);
+  const retry = document.getElementById(SELECTORS.retry);
   if (retry) {
     on(retry, 'click', async () => {
       if (!state.lastEmail) return;
@@ -447,6 +451,14 @@ export function init() {
     console.error('[Login] No encontré el formulario de login');
     return { teardown() {} };
   }
+
+  patchPreviewLinks({
+    'indexv2.html': 'indexv2.refactor.html',
+    'loginv2.html': 'loginv2.refactor.html',
+    'signupv2.html': 'signupv2.refactor.html',
+    'dashboardv3.html': 'dashboardv3.refactor.html',
+    'formsintrov3.html': 'formsintrov3.refactor.html',
+  });
 
   form.addEventListener('submit', handleSubmit);
   wireModalActions();

--- a/refactor/js/utils/dom.js
+++ b/refactor/js/utils/dom.js
@@ -197,3 +197,28 @@ export function serializeForm(form) {
   });
   return result;
 }
+
+// ===== [Feature: AjustarLinksPreview] =====
+// Qué hace: cuando navegamos dentro de /refactor/ reescribe href conocidos para apuntar
+//           a los archivos *.refactor sin romper las rutas finales.
+// Entradas/Salidas clave: recibe un objeto { original: reemplazo } y un scope opcional.
+// Notas: solo actúa en modo preview (cuando la URL contiene /refactor/).
+export function patchPreviewLinks(map, scope = document) {
+  if (typeof window === 'undefined') return;
+  if (!scope || !map) return;
+  const pathname = window.location?.pathname || '';
+  if (!pathname.includes('/refactor/')) return;
+
+  const entries = Object.entries(map).filter(([from, to]) => Boolean(from && to));
+  if (entries.length === 0) return;
+
+  const replacements = new Map(entries);
+  qsa('a[href]', scope).forEach((link) => {
+    const href = link.getAttribute('href') || '';
+    if (!href || href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('tel:') || href.startsWith('http')) {
+      return;
+    }
+    if (!replacements.has(href)) return;
+    link.setAttribute('href', replacements.get(href));
+  });
+}

--- a/refactor/views/dashboardv3.refactor.html
+++ b/refactor/views/dashboardv3.refactor.html
@@ -239,8 +239,12 @@
       let email = (url.searchParams.get('email') || localStorage.getItem('gj_email') || '').trim().toLowerCase();
       if (!email) return;
 
-      document.querySelectorAll('a[data-keep-email]').forEach(a => {
-        const u = new URL(a.getAttribute('href'), location.origin);
+      document.querySelectorAll('a[data-keep-email]').forEach((a) => {
+        const rawHref = a.getAttribute('href');
+        if (!rawHref) return;
+        const isPreview = location.pathname.includes('/refactor/') && rawHref.includes('.refactor');
+        const base = isPreview ? location.href : location.origin;
+        const u = new URL(rawHref, base);
         u.searchParams.set('email', email);
         a.setAttribute('href', u.toString());
       });


### PR DESCRIPTION
## Summary
- ensure landing/login/dashboard refactor views rewrite in-app links to their *.refactor counterparts when previewing the refactor tree
- restore the login error fallback so slow or failing checks reopen the await modal and continue polling, while silencing optional retry lookup errors
- adjust dashboard email helpers to respect preview URLs when generating keep-email links

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfa7a36b2883228f6436ca484d3dd9