### PR TITLE
Ensure renderPopup global availability before routing

### DIFF
--- a/refactor/js/features/popups.js
+++ b/refactor/js/features/popups.js
@@ -287,6 +287,10 @@ function renderPopup(item, onClose){
   }
 }
 
+if (typeof window !== 'undefined') {
+  window.renderPopup = renderPopup;
+}
+
 
 
 // ==== WEEK RECAP (renderer especializado) ====
@@ -706,7 +710,12 @@ function renderWeekRecapPopup(item, onClose){
 
 // ==== Router seguro: una sola envoltura, sin recursión ====
 (function attachWeekRecapRouter(){
+  if (typeof window === 'undefined') return;
   if (window.__GJ_POPUP_ROUTED__) return;
+  if (typeof window.renderPopup !== 'function'){
+    console.warn('[popups] window.renderPopup no está disponible para router Week Recap');
+    return;
+  }
   const ORIG = window.renderPopup.bind(window);
   window.__GJ_POPUP_ROUTED__ = true;
 


### PR DESCRIPTION
## Summary
- assign the renderPopup implementation to the window object when available
- guard the week recap router so it only wraps when window.renderPopup exists and logs otherwise

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfcbabe43c8322a3a0e8ce53a18938