### PR TITLE
Fix global stylesheet import and convert PostCSS config to ESM

### DIFF
--- a/npm/app/layout.tsx
+++ b/npm/app/layout.tsx
@@ -1,4 +1,4 @@
-import "@/styles/globals.css";
+import "../styles/globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
 import { ReactNode } from "react";
 

--- a/npm/next-env.d.ts
+++ b/npm/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/npm/postcss.config.js
+++ b/npm/postcss.config.js
@@ -1,6 +1,8 @@
-module.exports = {
+const config = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {}
-  }
+    autoprefixer: {},
+  },
 };
+
+export default config;

--- a/npm/tsconfig.json
+++ b/npm/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -12,13 +16,35 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["@types/node", "@clerk/nextjs/server"],
+    "types": [
+      "@types/node",
+      "@clerk/nextjs/server"
+    ],
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"]
-    }
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/lib/*": [
+        "lib/*"
+      ]
+    },
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- update the app layout to reference the global stylesheet with a resolvable relative path
- convert the PostCSS configuration to ESM syntax to align with the package module type
- accept Next.js TypeScript config adjustments applied during the first production build

## Testing
- npm run build *(fails: TypeError: Cannot read properties of undefined (reading 'clientModules') during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68e12b1924488322984bae5f61bd7f2f