### PR TITLE
Remove deprecated serverActions flag from Next config

### DIFF
--- a/npm/next.config.mjs
+++ b/npm/next.config.mjs
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    serverActions: true
-  },
+  experimental: {},
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- remove the legacy experimental.serverActions flag from the Next.js configuration so the related warning no longer appears during builds

## Testing
- `npm run build` *(fails: TypeError: Cannot read properties of undefined (reading 'clientModules') during prerendering of /(marketing)/page)*

------
https://chatgpt.com/codex/tasks/task_e_68e12bebe4ac8322ba28b8d3b345a036