### PR TITLE
Add ESLint dependencies to Next.js app

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -24,6 +24,8 @@
     "@types/react": "^18.2.54",
     "@types/react-dom": "^18.2.18",
     "autoprefixer": "^10.4.17",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.1.0",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary
- add eslint and eslint-config-next to the Next.js package.json dev dependencies

## Testing
- npm run build *(fails: ESLint must be installed; npm registry returned 403 during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68e12e64ec348322b7179f18819ed208