### PR TITLE
Use server-side Clerk middleware

### DIFF
--- a/npm/middleware.ts
+++ b/npm/middleware.ts
@@ -1,4 +1,4 @@
-import { authMiddleware } from "@clerk/nextjs";
+import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   publicRoutes: ["/", "/api/health", "/sign-in(.*)", "/sign-up(.*)"]


### PR DESCRIPTION
## Summary
- update the middleware to import Clerk's auth middleware from the server entrypoint

## Testing
- npm run build *(fails: TypeError: Cannot read properties of undefined (reading 'clientModules'))*

------
https://chatgpt.com/codex/tasks/task_e_68e132334d748322801c9113a6e01d42