### PR TITLE
Fix Clerk integration issues blocking static build

### DIFF
--- a/npm/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/npm/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SignIn } from "@clerk/nextjs";
 
 export default function SignInPage() {

--- a/npm/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/npm/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SignUp } from "@clerk/nextjs";
 
 export default function SignUpPage() {

--- a/npm/app/(dashboard)/dashboard/page.tsx
+++ b/npm/app/(dashboard)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { currentUser } from "@clerk/nextjs";
+import { currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 

--- a/npm/app/(marketing)/page.tsx
+++ b/npm/app/(marketing)/page.tsx
@@ -11,6 +11,8 @@ import { Steps } from "@/components/Steps";
 import { Testimonials } from "@/components/Testimonials";
 import { BarChart3, Gift, Sparkles } from "lucide-react";
 
+export const dynamic = "force-dynamic";
+
 export default function MarketingPage() {
   return (
     <div className="flex min-h-screen flex-col">

--- a/npm/components/Navbar.tsx
+++ b/npm/components/Navbar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 import { Container } from "./Container";

--- a/npm/lib/auth.ts
+++ b/npm/lib/auth.ts
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs";
+import { auth } from "@clerk/nextjs/server";
 
 export function requireAuth() {
   const { userId } = auth();


### PR DESCRIPTION
## Summary
- mark Clerk-driven UI components as client components so they render correctly
- use server-side Clerk helpers in dashboard and auth utilities to align with App Router conventions
- force the marketing page to render dynamically to avoid prerender failures when Clerk context is required

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e133577bd48322be45d7497ba8697d