### PR TITLE
Fix npm CI cache removal failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+node_modules/
+.npm/
+.next/
+.env
+.env.local
+.env.production
+.env.development
+.DS_Store
+.vercel/
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Typescript
+*.tsbuildinfo
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --check refactor/js/features/formsintrov2.js"
+    "preinstall": "rm -rf node_modules/.cache || true",
+    "test": "node --check refactor/js/features/formsintrov2.js",
+    "prebuild": "npm ci --prefix npm",
+    "build": "npm run build --prefix npm",
+    "postbuild": "rm -rf npm/node_modules/.cache || true"
   }
 }


### PR DESCRIPTION
## Summary
- add npm scripts to clean cache folders and delegate the Next.js build inside the npm subdirectory
- ensure the build step installs the nested app dependencies before running
- ignore development artifacts such as node_modules, build outputs, and environment files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e13fc915648322af61b69a499c27da