### PR TITLE
Add database SQL runner scripts

### DIFF
--- a/db/sql/schema.sql
+++ b/db/sql/schema.sql
@@ -1,0 +1,215 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;  -- we use gen_random_uuid()
+
+-- Tipos
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'game_mode') THEN
+    CREATE TYPE game_mode AS ENUM ('LOW','CHILL','FLOW','EVOLVE');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'difficulty') THEN
+    CREATE TYPE difficulty AS ENUM ('EASY','MEDIUM','HARD');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mission_status') THEN
+    CREATE TYPE mission_status AS ENUM ('ACTIVE','COMPLETED','FAILED');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'job_status') THEN
+    CREATE TYPE job_status AS ENUM ('QUEUED','RUNNING','DONE','ERROR');
+  END IF;
+END$$;
+
+-- === 1) Identidad de usuario (Clerk como autoridad) ===
+CREATE TABLE app_user (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clerk_user_id   TEXT UNIQUE NOT NULL,
+  email           CITEXT,
+  display_name    TEXT,
+  avatar_url      TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON app_user (clerk_user_id);
+
+CREATE TABLE user_profile (
+  user_id         UUID PRIMARY KEY REFERENCES app_user(id) ON DELETE CASCADE,
+  game_mode       game_mode,
+  pace            TEXT,                 -- "Low/Chill/Normal/Shark" (o los finales)
+  timezone        TEXT,
+  status          TEXT NOT NULL DEFAULT 'active',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- === 2) Taxonomía base (catálogo global) ===
+CREATE TABLE pillar (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code        TEXT UNIQUE NOT NULL,     -- BODY / MIND / SOUL
+  name        TEXT NOT NULL
+);
+
+CREATE TABLE trait (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pillar_id   UUID NOT NULL REFERENCES pillar(id) ON DELETE CASCADE,
+  code        TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  UNIQUE (pillar_id, code)
+);
+
+CREATE TABLE stat (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trait_id    UUID NOT NULL REFERENCES trait(id) ON DELETE CASCADE,
+  code        TEXT NOT NULL,
+  name        TEXT NOT NULL,
+  UNIQUE (trait_id, code)
+);
+
+CREATE TABLE task_catalog (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  stat_id       UUID NOT NULL REFERENCES stat(id) ON DELETE CASCADE,
+  code          TEXT NOT NULL,
+  name          TEXT NOT NULL,
+  difficulty    difficulty NOT NULL,
+  base_xp       INTEGER NOT NULL DEFAULT 10,
+  is_active     BOOLEAN NOT NULL DEFAULT TRUE,
+  UNIQUE (stat_id, code)
+);
+
+-- === 3) Instancias personalizadas por usuario ===
+CREATE TABLE user_task (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  task_catalog_id UUID REFERENCES task_catalog(id) ON DELETE SET NULL,
+  pillar_id       UUID NOT NULL REFERENCES pillar(id),
+  trait_id        UUID NOT NULL REFERENCES trait(id),
+  stat_id         UUID NOT NULL REFERENCES stat(id),
+  name            TEXT NOT NULL,
+  difficulty      difficulty NOT NULL,
+  base_xp         INTEGER NOT NULL,
+  is_active       BOOLEAN NOT NULL DEFAULT TRUE,
+  position        INTEGER,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON user_task (user_id, is_active);
+
+-- === 4) Datos diarios ===
+CREATE TABLE daily_log (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  user_task_id  UUID REFERENCES user_task(id) ON DELETE SET NULL,
+  task_name     TEXT NOT NULL,
+  done_at       DATE NOT NULL,
+  qty           INTEGER NOT NULL DEFAULT 1,
+  xp_earned     INTEGER NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, user_task_id, done_at, task_name)
+);
+CREATE INDEX ON daily_log (user_id, done_at);
+
+CREATE TABLE daily_emotion (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  date          DATE NOT NULL,
+  emotion_key   TEXT NOT NULL,
+  emotion_raw   TEXT,
+  note          TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, date)
+);
+CREATE INDEX ON daily_emotion (user_id, date);
+
+-- === 5) Snapshot/caché de progreso (derivable, pero útil) ===
+CREATE TABLE user_progress_snapshot (
+  user_id       UUID PRIMARY KEY REFERENCES app_user(id) ON DELETE CASCADE,
+  total_xp      INTEGER NOT NULL DEFAULT 0,
+  level         INTEGER NOT NULL DEFAULT 1,
+  xp_to_next    INTEGER NOT NULL DEFAULT 100,
+  journey_days  INTEGER NOT NULL DEFAULT 0,
+  base_state    TEXT,           -- 'modificada' / 'constante'
+  streak_d      INTEGER NOT NULL DEFAULT 0,  -- racha diaria actual
+  c1s_cur       INTEGER NOT NULL DEFAULT 0,  -- rachas semanales actuales
+  c2s_cur       INTEGER NOT NULL DEFAULT 0,
+  c3s_cur       INTEGER NOT NULL DEFAULT 0,
+  c4s_cur       INTEGER NOT NULL DEFAULT 0,
+  c1s_max       INTEGER NOT NULL DEFAULT 0,  -- rachas máximas
+  c2s_max       INTEGER NOT NULL DEFAULT 0,
+  c3s_max       INTEGER NOT NULL DEFAULT 0,
+  c4s_max       INTEGER NOT NULL DEFAULT 0,
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- === 6) Hábitos graduados ===
+CREATE TABLE habit_achieved (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  user_task_id  UUID REFERENCES user_task(id) ON DELETE SET NULL,
+  task_name     TEXT NOT NULL,
+  achieved_on   DATE NOT NULL,
+  reason        TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON habit_achieved (user_id, achieved_on);
+
+-- === 7) Prompts / IA ===
+CREATE TABLE ai_prompt (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES app_user(id) ON DELETE SET NULL,
+  mode          game_mode,
+  status        TEXT NOT NULL DEFAULT 'PENDING',
+  input_text    TEXT NOT NULL,
+  output_json   JSONB,
+  error_text    TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  done_at       TIMESTAMPTZ
+);
+CREATE INDEX ON ai_prompt (user_id, status);
+
+-- === 8) Misiones / Recompensas ===
+CREATE TABLE mission (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  code          TEXT UNIQUE NOT NULL,
+  name          TEXT NOT NULL,
+  description   TEXT,
+  goal_desc     TEXT,
+  difficulty    difficulty,
+  bonus_type    TEXT,           -- 'xp_multiplier' | 'xp_bonus'
+  bonus_value   NUMERIC,        -- 1.5 o 50
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE user_mission (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES app_user(id) ON DELETE CASCADE,
+  mission_id    UUID NOT NULL REFERENCES mission(id) ON DELETE CASCADE,
+  status        mission_status NOT NULL DEFAULT 'ACTIVE',
+  started_at    DATE NOT NULL DEFAULT CURRENT_DATE,
+  completed_at  DATE,
+  progress_json JSONB,
+  UNIQUE (user_id, mission_id, status)
+);
+CREATE INDEX ON user_mission (user_id, status);
+
+-- === 9) Emails / Jobs (orquestación) ===
+CREATE TABLE email_log (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES app_user(id) ON DELETE SET NULL,
+  to_email      CITEXT NOT NULL,
+  template_key  TEXT NOT NULL,
+  subject       TEXT,
+  payload_json  JSONB,
+  sent_at       TIMESTAMPTZ,
+  status        TEXT NOT NULL DEFAULT 'QUEUED',
+  error_text    TEXT
+);
+
+CREATE TABLE job_schedule (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_type      TEXT NOT NULL,           -- 'send_daily_form', 'recalc_weekly', etc.
+  user_id       UUID REFERENCES app_user(id) ON DELETE CASCADE,
+  cron_expr     TEXT NOT NULL,
+  active        BOOLEAN NOT NULL DEFAULT TRUE,
+  last_run_at   TIMESTAMPTZ,
+  status        job_status NOT NULL DEFAULT 'QUEUED',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON job_schedule (job_type, active);

--- a/db/sql/seeds.sql
+++ b/db/sql/seeds.sql
@@ -1,0 +1,108 @@
+-- Pillars
+INSERT INTO pillar (code, name) VALUES
+  ('BODY','Cuerpo'), ('MIND','Mente'), ('SOUL','Alma')
+ON CONFLICT (code) DO NOTHING;
+
+-- Traits + Stats + Catálogo base (ejemplo rápido)
+WITH p_body AS (SELECT id FROM pillar WHERE code='BODY'),
+     p_mind AS (SELECT id FROM pillar WHERE code='MIND'),
+     p_soul AS (SELECT id FROM pillar WHERE code='SOUL')
+INSERT INTO trait (pillar_id, code, name)
+SELECT id, 'REST','Descanso' FROM p_body
+ON CONFLICT DO NOTHING;
+
+WITH t_rest AS (
+  SELECT t.id FROM trait t JOIN pillar p ON p.id=t.pillar_id
+  WHERE p.code='BODY' AND t.code='REST'
+)
+INSERT INTO stat (trait_id, code, name)
+SELECT id, 'SLEEP','Sueño' FROM t_rest
+ON CONFLICT DO NOTHING;
+
+WITH s_sleep AS (
+  SELECT s.id FROM stat s JOIN trait t ON t.id=s.trait_id
+  JOIN pillar p ON p.id=t.pillar_id
+  WHERE p.code='BODY' AND t.code='REST' AND s.code='SLEEP'
+)
+INSERT INTO task_catalog (stat_id, code, name, difficulty, base_xp)
+SELECT id, 'SLEEP_7H', 'Dormir 7h', 'EASY', 10 FROM s_sleep
+ON CONFLICT DO NOTHING;
+
+-- Mind
+INSERT INTO trait (pillar_id, code, name)
+SELECT id, 'FOCUS','Enfoque' FROM p_mind
+ON CONFLICT DO NOTHING;
+
+WITH t_focus AS (
+  SELECT t.id FROM trait t JOIN pillar p ON p.id=t.pillar_id
+  WHERE p.code='MIND' AND t.code='FOCUS'
+)
+INSERT INTO stat (trait_id, code, name)
+SELECT id, 'READ','Lectura' FROM t_focus
+ON CONFLICT DO NOTHING;
+
+WITH s_read AS (
+  SELECT s.id FROM stat s JOIN trait t ON t.id=s.trait_id
+  JOIN pillar p ON p.id=t.pillar_id
+  WHERE p.code='MIND' AND t.code='FOCUS' AND s.code='READ'
+)
+INSERT INTO task_catalog (stat_id, code, name, difficulty, base_xp)
+SELECT id, 'READ_10', 'Leer 10 min', 'EASY', 10 FROM s_read
+ON CONFLICT DO NOTHING;
+
+-- Soul
+INSERT INTO trait (pillar_id, code, name)
+SELECT id, 'EMO','Emociones' FROM p_soul
+ON CONFLICT DO NOTHING;
+
+WITH t_emo AS (
+  SELECT t.id FROM trait t JOIN pillar p ON p.id=t.pillar_id
+  WHERE p.code='SOUL' AND t.code='EMO'
+)
+INSERT INTO stat (trait_id, code, name)
+SELECT id, 'JOURNAL','Registro emocional' FROM t_emo
+ON CONFLICT DO NOTHING;
+
+WITH s_journal AS (
+  SELECT s.id FROM stat s JOIN trait t ON t.id=s.trait_id
+  JOIN pillar p ON p.id=t.pillar_id
+  WHERE p.code='SOUL' AND t.code='EMO' AND s.code='JOURNAL'
+)
+INSERT INTO task_catalog (stat_id, code, name, difficulty, base_xp)
+SELECT id, 'JOURNAL_1', 'Escribir 1 reflexión', 'EASY', 10 FROM s_journal
+ON CONFLICT DO NOTHING;
+
+-- Usuario demo (Clerk)
+INSERT INTO app_user (clerk_user_id, email, display_name)
+VALUES ('clerk_demo_123','demo@innerbloom.app','Demo')
+ON CONFLICT (clerk_user_id) DO NOTHING;
+
+INSERT INTO user_profile (user_id, game_mode, pace, timezone)
+SELECT id, 'CHILL','Normal','Europe/Berlin'
+FROM app_user WHERE clerk_user_id='clerk_demo_123'
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Instanciar tasks base para el usuario demo
+INSERT INTO user_task (user_id, task_catalog_id, pillar_id, trait_id, stat_id, name, difficulty, base_xp)
+SELECT u.id, tc.id, tr.pillar_id, tr.id, s.id, tc.name, tc.difficulty, tc.base_xp
+FROM app_user u
+CROSS JOIN task_catalog tc
+JOIN stat s   ON s.id=tc.stat_id
+JOIN trait tr ON tr.id=s.trait_id
+WHERE u.clerk_user_id='clerk_demo_123';
+
+-- Un par de logs y emociones
+INSERT INTO daily_log (user_id, user_task_id, task_name, done_at, qty, xp_earned)
+SELECT u.id, ut.id, ut.name, CURRENT_DATE - 1, 1, ut.base_xp
+FROM app_user u
+JOIN user_task ut ON ut.user_id=u.id
+WHERE u.clerk_user_id='clerk_demo_123'
+LIMIT 2;
+
+INSERT INTO daily_emotion (user_id, date, emotion_key, emotion_raw)
+SELECT u.id, CURRENT_DATE - 1, 'Calm', '🟦 Calm - centered' FROM app_user u WHERE u.clerk_user_id='clerk_demo_123'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO daily_emotion (user_id, date, emotion_key, emotion_raw)
+SELECT u.id, CURRENT_DATE, 'Focused', '🟩 Focused - clear' FROM app_user u WHERE u.clerk_user_id='clerk_demo_123'
+ON CONFLICT DO NOTHING;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --check refactor/js/features/formsintrov2.js"
+    "test": "node --check refactor/js/features/formsintrov2.js",
+    "db:schema": "node scripts/db-runner.mjs schema",
+    "db:seeds": "node scripts/db-runner.mjs seeds",
+    "db:all": "node scripts/db-runner.mjs all"
+  },
+  "dependencies": {
+    "pg": "^8.11.3"
   }
 }

--- a/scripts/db-runner.mjs
+++ b/scripts/db-runner.mjs
@@ -1,0 +1,55 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import pg from "pg";
+
+const { Client } = pg;
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function readSql(relPath) {
+  const full = path.resolve(__dirname, "..", relPath);
+  if (!fs.existsSync(full)) {
+    throw new Error(`Archivo SQL no encontrado: ${full}`);
+  }
+  return fs.readFileSync(full, "utf8");
+}
+
+async function runSql(label, sql) {
+  const connStr = process.env.DATABASE_URL;
+  if (!connStr) throw new Error("DATABASE_URL no definido");
+  const client = new Client({
+    connectionString: connStr,
+    ssl: { rejectUnauthorized: false } // Railway requires SSL
+  });
+  await client.connect();
+  try {
+    console.log(`\n=== Ejecutando ${label} ===`);
+    await client.query(sql);
+    console.log(`✔ OK: ${label}`);
+  } finally {
+    await client.end();
+  }
+}
+
+const cmd = process.argv[2]; // "schema" | "seeds" | "all"
+if (!cmd) {
+  console.error("Uso: node scripts/db-runner.mjs <schema|seeds|all>");
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    if (cmd === "schema" || cmd === "all") {
+      const ddl = readSql("../db/sql/schema.sql");
+      await runSql("schema.sql", ddl);
+    }
+    if (cmd === "seeds" || cmd === "all") {
+      const seeds = readSql("../db/sql/seeds.sql");
+      await runSql("seeds.sql", seeds);
+    }
+    console.log("\nTodo listo ✅");
+  } catch (err) {
+    console.error("\n❌ Error:", err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a Node-based runner under scripts/db-runner.mjs to execute schema and seed SQL with pg and SSL
- copy the schema and seed SQL into db/sql with gen_random_uuid() defaults and required extensions
- expose npm commands for running schema, seeds, or both and declare the pg dependency

## Testing
- npm i pg *(fails in container: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e142deafe88322a2ff212dcabe26c5