### PR TITLE
Configure Nixpacks to install dependencies from nested Next.js app

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,17 @@
+[phases.setup]
+nixPkgs = ["nodejs_20"]
+
+[phases.install]
+cmds = [
+  "cd npm && rm -rf node_modules/.cache || true",
+  "cd npm && rm -rf node_modules || true",
+  "cd npm && npm ci"
+]
+
+[phases.build]
+cmds = [
+  "cd npm && npm run build"
+]
+
+[start]
+cmd = "cd npm && npm run start"


### PR DESCRIPTION
## Summary
- add a Nixpacks configuration so Railway installs and builds from the `npm` subdirectory
- proactively remove any cached `node_modules` content before running `npm ci` to avoid EBUSY errors during cleanup
- ensure the runtime command also starts the Next.js app from the nested folder

## Testing
- not run (network-restricted environment)

------
https://chatgpt.com/codex/tasks/task_e_68e14490d1048322ba0f5c1e8e1bc760