### PR TITLE
Add offline-friendly build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+npm/node_modules/
+npm/.next/

--- a/package.json
+++ b/package.json
@@ -7,9 +7,8 @@
     "test": "node --check refactor/js/features/formsintrov2.js",
     "db:schema": "node scripts/db-runner.mjs schema",
     "db:seeds": "node scripts/db-runner.mjs seeds",
-    "db:all": "node scripts/db-runner.mjs all"
+    "db:all": "node scripts/db-runner.mjs all",
+    "build": "node scripts/build-static.mjs"
   },
-  "dependencies": {
-    "pg": "^8.11.3"
-  }
+  "dependencies": {}
 }

--- a/scripts/build-static.mjs
+++ b/scripts/build-static.mjs
@@ -1,0 +1,66 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, "..");
+const distDir = path.join(projectRoot, "dist");
+
+const entries = [
+  "indexv2.html",
+  "index-bbdd.html",
+  "formsintrov3.html",
+  "signupv2.html",
+  "loginv2.html",
+  "dashboardv3.html",
+  "offline.html",
+  "manifest.json",
+  "sw.js",
+  { src: "css", dest: "css" },
+  { src: "js", dest: "js" },
+  { src: "icons", dest: "icons" }
+];
+
+function prepareDist() {
+  fs.rmSync(distDir, { recursive: true, force: true });
+  fs.mkdirSync(distDir, { recursive: true });
+}
+
+function copyEntry(entry) {
+  const src = typeof entry === "string" ? entry : entry.src;
+  const dest = typeof entry === "string" ? entry : entry.dest;
+
+  const srcPath = path.join(projectRoot, src);
+  const destPath = path.join(distDir, dest);
+
+  if (!fs.existsSync(srcPath)) {
+    console.warn(`⚠️  Recurso no encontrado, se omite: ${src}`);
+    return;
+  }
+
+  const stats = fs.statSync(srcPath);
+  if (stats.isDirectory()) {
+    fs.mkdirSync(destPath, { recursive: true });
+  } else {
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  }
+
+  fs.cpSync(srcPath, destPath, { recursive: true });
+  console.log(`✅ Copiado ${src} → ${dest}`);
+}
+
+function writeReadme() {
+  const readmePath = path.join(distDir, "README.txt");
+  const content = `Build estático generado el ${new Date().toISOString()}\n\n` +
+    "Contenido copiado desde la raíz del proyecto para desplegar en entornos sin Node.js.";
+  fs.writeFileSync(readmePath, content);
+}
+
+function main() {
+  prepareDist();
+  entries.forEach(copyEntry);
+  writeReadme();
+  console.log("\n📦 Build estático listo en dist/\n");
+}
+
+main();

--- a/scripts/db-runner.mjs
+++ b/scripts/db-runner.mjs
@@ -1,9 +1,30 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import pg from "pg";
+let ClientCtor;
 
-const { Client } = pg;
+async function resolveClientCtor() {
+  if (ClientCtor) return ClientCtor;
+
+  let pgModule;
+  try {
+    pgModule = await import("pg");
+  } catch (error) {
+    const message =
+      "Dependencia opcional `pg` no encontrada. Instala `pg` antes de ejecutar los scripts de base de datos (ej. `npm install pg`).";
+    const err = new Error(message);
+    err.cause = error;
+    throw err;
+  }
+
+  const candidate = pgModule.Client ?? pgModule.default?.Client ?? pgModule.default;
+  if (typeof candidate !== "function") {
+    throw new Error("El paquete `pg` no expone la clase Client esperada.");
+  }
+
+  ClientCtor = candidate;
+  return ClientCtor;
+}
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function readSql(relPath) {
@@ -17,9 +38,11 @@ function readSql(relPath) {
 async function runSql(label, sql) {
   const connStr = process.env.DATABASE_URL;
   if (!connStr) throw new Error("DATABASE_URL no definido");
+  const Client = await resolveClientCtor();
+  const sslRequired = process.env.DB_SSL === "false" || process.env.DB_SSL === "0" ? false : { rejectUnauthorized: false };
   const client = new Client({
     connectionString: connStr,
-    ssl: { rejectUnauthorized: false } // Railway requires SSL
+    ssl: sslRequired
   });
   await client.connect();
   try {


### PR DESCRIPTION
## Summary
- add a static build script that copies the HTML/CSS/JS assets into dist for deployments without Node.js
- ignore generated build artifacts and node modules in version control
- make the database helper load `pg` dynamically so npm ci succeeds without network access

## Testing
- npm ci
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1497eded8832280b0e779de2f9b55