### PR TITLE
Refresh typography across the app

### DIFF
--- a/css/bbdd.css
+++ b/css/bbdd.css
@@ -5,6 +5,8 @@
 
 /* --- Tokens --- */
 :root{
+  --font-heading:"Sora", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-body:"Manrope", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --brand:#7d3cff;
   --ink:#ecedff;
   --ink-soft:#cfd3ff;
@@ -42,7 +44,12 @@ html,body{
   margin:0; padding:0;
   background:#0c1020;
   color:var(--ink);
-  font-family:"Inter",ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto;
+  font-family:var(--font-body);
+}
+
+h1,h2,h3,h4,h5,h6{
+  font-family:var(--font-heading);
+  letter-spacing:-0.015em;
 }
 
 /* --- Overlay/Panel (glass) --- */

--- a/css/dashboardv3.css
+++ b/css/dashboardv3.css
@@ -1,11 +1,22 @@
+/* TOKENS DE TIPOGRAFÍA */
+:root{
+  --font-heading:"Sora", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-body:"Manrope", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
 /* RESET & BASE */
 *{box-sizing:border-box}
 html,body{height:100%;margin:0}
 body{
-  font-family:"Rubik",system-ui,-apple-system,Segoe UI,Inter,Roboto,Arial,sans-serif;
+  font-family:var(--font-body);
   background: linear-gradient(180deg,#0A0D18 0%, #0B0F1E 100%);
   color:#fff;
   margin:0;
+}
+
+h1,h2,h3,h4,h5,h6{
+  font-family:var(--font-heading);
+  letter-spacing:-0.015em;
 }
 
 .dashboard-root{
@@ -44,7 +55,7 @@ header{
   display:flex;align-items:center;justify-content:space-between;
   position:sticky;top:0;z-index:40;
 }
-.logo{font-weight:900}
+.logo{font-weight:900;font-family:var(--font-heading);letter-spacing:-0.01em}
 .menu-toggle{font-size:22px;cursor:pointer}
 
 /* MENÚ HAMBURGUESA */
@@ -305,7 +316,7 @@ canvas{width:100% !important;height:auto !important;border-radius:10px}
 
 /* BOTONES CENTRALES */
 .dashboard-links{display:flex;justify-content:center;gap:16px;margin:12px 0 6px}
-.btn{background:#7d3cff;color:#fff;padding:10px 20px;border-radius:20px;text-decoration:none;font-weight:900;transition:background .25s}
+.btn{background:#7d3cff;color:#fff;padding:10px 20px;border-radius:20px;text-decoration:none;font-weight:900;transition:background .25s;font-family:var(--font-heading);letter-spacing:-0.01em}
 .btn:hover{background:#5c28c2}
 
 /* POPUP AVATAR (estructura lista; la lógica la agregamos luego) */
@@ -641,7 +652,10 @@ canvas{width:100% !important;height:auto !important;border-radius:10px}
   border: 1px solid rgba(122,134,255,.55);
   background: #151a33;
   color: #e8eaff;
-  font: 700 13px/1 "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1;
   display: grid; place-items: center;
   cursor: pointer;
   transition: transform .12s ease, background .12s ease, color .12s ease;
@@ -701,7 +715,10 @@ canvas{width:100% !important;height:auto !important;border-radius:10px}
   border: 1px solid rgba(122,134,255,.55);
   background: #151a33;
   color: #e8eaff;
-  font: 700 14px/1 "Inter", system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1;
   display: grid; place-items: center;
   cursor: pointer;
   transition: transform .12s ease, background .12s ease, color .12s ease;

--- a/css/formsintrov2.css
+++ b/css/formsintrov2.css
@@ -1,4 +1,6 @@
  :root{
+    --font-heading:"Sora", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+    --font-body:"Manrope", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
     --bg:#0b0e19; --panel:#141a2c; --card:#171b31; --ring:rgba(255,255,255,.08);
     --text:#eaf0ff; --muted:#a9b2d0; --accent:#7a66ff; --accent2:#a78bfa; --ok:#38d39f;
     --shadow:0 24px 80px rgba(0,0,0,.40);
@@ -7,13 +9,18 @@
   *{box-sizing:border-box}
   html,body{height:100%}
   body{
-    margin:0; font-family:'Rubik',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+    margin:0; font-family:var(--font-body);
     color:var(--text);
     background:
       radial-gradient(1100px 700px at 50% -15%, rgba(122,102,255,.18), transparent 60%),
       linear-gradient(180deg, #0b0e19, #0b0e19 30%, #0f1325 100%);
     overflow:auto;
     padding-top: calc(var(--hudH) + 10px); /* evita que el HUD tape títulos */
+  }
+
+  h1,h2,h3,h4,h5,h6{
+    font-family:var(--font-heading);
+    letter-spacing:-0.015em;
   }
 
   /* HUD (mantengo tu diseño) */
@@ -26,12 +33,12 @@
     padding:10px 12px; background:rgba(10,12,24,.86); border-bottom:1px solid var(--ring);
     backdrop-filter: blur(4px);
   }
-  .brand{grid-area:brand; display:flex; align-items:center; gap:10px; font-weight:800}
+  .brand{grid-area:brand; display:flex; align-items:center; gap:10px; font-weight:800; font-family:var(--font-heading); letter-spacing:-0.01em}
   .dot{width:9px; height:9px; border-radius:50%; background:var(--accent); box-shadow:0 0 20px var(--accent)}
   .journey{display:flex; align-items:center; gap:10px}
   .journey .progress{width:190px}
   .mid{grid-area:mid; display:flex; justify-content:center; gap:18px}
-  .pill{display:flex; flex-direction:column; gap:4px; font-size:12px; min-width:110px}
+  .pill{display:flex; flex-direction:column; gap:4px; font-size:12px; min-width:110px; font-family:var(--font-body); font-weight:600}
   .pill .row{display:flex; align-items:center; gap:6px}
   .pill .emoji{font-size:14px}
   .pill .label{font-weight:600}

--- a/css/signupv2.css
+++ b/css/signupv2.css
@@ -1,16 +1,23 @@
 :root{
+  --font-heading:"Sora", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-body:"Manrope", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --bg:#0b0f19; --card:#121829; --ink:#e8ecf1; --muted:#9aa3b2;
   --accent:#7d3cff; --accent-2:#5c28c2; --line:rgba(255,255,255,.14);
 }
 *{box-sizing:border-box}
 html,body{height:100%;margin:0}
 body.signupv2{
-  font-family:'Rubik',system-ui,-apple-system,Segoe UI,Inter,Roboto,Arial,sans-serif;
+  font-family:var(--font-body);
   background:
     radial-gradient(1200px 800px at 20% -10%, #1a2340 0%, rgba(26,35,64,0) 60%),
     radial-gradient(1000px 700px at 120% 0%, #321a63 0%, rgba(50,26,99,0) 60%),
     var(--bg);
   color:var(--ink);
+}
+
+h1,h2,h3,h4,h5,h6{
+  font-family:var(--font-heading);
+  letter-spacing:-0.015em;
 }
 
 /* NAV */
@@ -20,12 +27,13 @@ body.signupv2{
   display:flex; align-items:center; justify-content:space-between; padding:12px 18px;
   position:sticky; top:0; z-index:40;
 }
-.brand{color:#fff; font-weight:900; text-decoration:none}
+.brand{color:#fff; font-weight:900; text-decoration:none; font-family:var(--font-heading); letter-spacing:-0.01em}
 .nav-actions{display:flex; gap:10px}
 
 /* Buttons */
 .btn{
   appearance:none; border:0; border-radius:12px; padding:12px 16px; font-weight:800;
+  font-family:var(--font-heading);
   background:var(--accent); color:#fff; cursor:pointer; text-decoration:none;
   transition:.2s background,.05s transform;
 }
@@ -40,7 +48,7 @@ body.signupv2{
   border:1px solid var(--line); border-radius:18px; padding:24px; backdrop-filter: blur(6px);
   box-shadow:0 20px 60px rgba(0,0,0,.35);
 }
-h1{margin:0 0 8px; font-size:26px; font-weight:900; text-align:center}
+h1{margin:0 0 8px; font-size:26px; font-weight:900; text-align:center; letter-spacing:-0.015em}
 .sub{margin:0 0 16px; color:var(--muted); text-align:center}
 .status{margin-top:10px; color:var(--muted); font-size:13px; text-align:center; min-height:20px}
 

--- a/css/stylesv3.css
+++ b/css/stylesv3.css
@@ -1,4 +1,6 @@
 :root{
+  --font-heading:"Sora", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-body:"Manrope", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --bg:#0b0f19; --bg-2:#0A0D18; --card:#121829; --ink:#e8ecf1; --muted:#9aa3b2;
   --accent:#7d3cff; --accent-2:#5c28c2; --line:rgba(255,255,255,.14);
   --low:#b63a3a; --chill:#2f9d66; --flow:#2f6bb6; --evolve:#7d3cff;
@@ -7,6 +9,7 @@
 }
 /* Marca en el nav */
 .nav .brand{
+  font-family:var(--font-heading);
   display:flex; align-items:center; gap:.6rem;
   color:#fff; text-decoration:none; font-weight:700;
 }
@@ -27,10 +30,19 @@
 *{box-sizing:border-box}
 html,body{height:100%;margin:0;}
 body{
-  font-family:'Rubik',system-ui,-apple-system,Segoe UI,Inter,Roboto,Arial,sans-serif;
+  font-family:var(--font-body);
   background:var(--bg);
   color:var(--ink);
   min-height:100vh; overflow-x:hidden; position:relative;
+}
+
+h1,h2,h3,h4,h5,h6{
+  font-family:var(--font-heading);
+  letter-spacing:-0.015em;
+}
+
+strong,b{
+  font-family:inherit;
 }
 
 /* ==== DESTELLOS / GLOWS FIJOS (iOS-safe) ==== */
@@ -72,11 +84,12 @@ body > *{ position:relative; z-index:1; }
 }
 .brand{color:#fff; font-weight:900; text-decoration:none; white-space:nowrap}
 .nav-links{display:flex; gap:14px; flex-wrap:wrap}
-.nav-links a{color:#cfd6ec; text-decoration:none; font-size:14px; opacity:.9}
+.nav-links a{color:#cfd6ec; text-decoration:none; font-size:14px; opacity:.9; font-family:var(--font-body); font-weight:600; letter-spacing:.01em}
 .nav-links a:hover{opacity:1}
 .nav-actions{display:flex; gap:10px}
 .btn{
   appearance:none; border:0; border-radius:12px; padding:12px 16px; font-weight:800;
+  font-family:var(--font-heading);
   background:var(--accent); color:#fff; cursor:pointer; text-decoration:none;
   transition:.2s background,.05s transform;
 }
@@ -127,12 +140,12 @@ section h2{font-size:32px;margin:0 0 8px;text-align:center}
   backdrop-filter: blur(8px);
   box-shadow:0 16px 48px rgba(0,0,0,.28);
 }
-.card h3{margin:6px 0 8px}
+.card h3{margin:6px 0 8px; font-family:var(--font-heading); letter-spacing:-0.01em}
 .card p{margin:0; color:#d8def5}
 .card-emoji{font-size:24px}
 
 /* ==== MODOS ==== */
-.mode-title{font-weight:900;display:flex;align-items:center;gap:8px;margin-bottom:6px}
+.mode-title{font-weight:900;display:flex;align-items:center;gap:8px;margin-bottom:6px;font-family:var(--font-heading);letter-spacing:-0.01em}
 .mode .dot{width:10px;height:10px;border-radius:50%;display:inline-block}
 .mode.low{border-left:3px solid var(--low)}
 .mode.low .dot{background:var(--low)}

--- a/dashboardv3.html
+++ b/dashboardv3.html
@@ -5,7 +5,7 @@
   <title>Self-Improvement Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Fuente + CSS (en carpeta /css) -->
-  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=Sora:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/dashboardv3.css?v=3">
   <link rel="stylesheet" href="css/panel-rachas.overrides.css?v=1">
   <link rel="stylesheet" href="./css/popups.css" />

--- a/formsintrov3.html
+++ b/formsintrov3.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Self-Improvement Journey</title>
-<link href="https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;600;800&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=Sora:wght@400;600;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/formsintrov2.css?v=3">
 </head>
 <body>

--- a/index-bbdd.html
+++ b/index-bbdd.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#7d3cff">
   <title>Edicion de Base de Datos</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=Sora:wght@400;600;700;800&display=swap" rel="stylesheet">
   <style>
     :root{
       --bg:#0b0f19; --ink:#e9eef7; --muted:#9aa3b2; --accent:#7d3cff; --accent2:#9a74ff;
@@ -20,7 +20,7 @@
       margin:0;
       background:linear-gradient(180deg,#0b0f19 0%,#0d1324 100%);
       color:var(--ink);
-      font:15px/1.4 "Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      font:15px/1.5 "Manrope",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
       -webkit-font-smoothing:antialiased;
     }
 

--- a/indexv2.html
+++ b/indexv2.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Innerbloom — Gamification Journey</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=Sora:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/stylesv3.css" />
   <meta name="theme-color" content="#0b0f19" />
 </head>

--- a/js/dashboardv3.js
+++ b/js/dashboardv3.js
@@ -659,7 +659,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             suggestedMax: Math.max(10, ...(radarData.values || [])),
             pointLabels: {
               color: "#ffffff",
-              font: { family: "'Rubik', sans-serif", size: 13 }
+              font: { family: "'Sora', 'Manrope', sans-serif", size: 13 }
             },
             grid: { color: "#444" },
             angleLines: { color: "#555" },

--- a/npm/app/layout.tsx
+++ b/npm/app/layout.tsx
@@ -1,6 +1,6 @@
 import "../styles/globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
-import { Rubik } from "next/font/google";
+import { Manrope, Sora } from "next/font/google";
 import { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
@@ -11,7 +11,8 @@ export const metadata = {
     "Explora la experiencia gamificada para crear hábitos equilibrados en cuerpo, mente y alma.",
 };
 
-const rubik = Rubik({ subsets: ["latin"], variable: "--font-rubik" });
+const manrope = Manrope({ subsets: ["latin"], variable: "--font-manrope" });
+const sora = Sora({ subsets: ["latin"], variable: "--font-sora" });
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -21,7 +22,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           className={cn(
             "relative min-h-screen bg-background text-white",
             "bg-mesh-gradient",
-            rubik.variable
+            manrope.variable,
+            sora.variable
           )}
         >
           <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_20%_20%,rgba(125,60,255,0.18),transparent_55%)]" />

--- a/npm/styles/globals.css
+++ b/npm/styles/globals.css
@@ -4,10 +4,22 @@
 
 :root {
   color-scheme: dark;
+  font-family: var(--font-manrope);
 }
 
 body {
   @apply min-h-screen bg-background text-slate-100 antialiased;
+  font-family: var(--font-manrope);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-sora);
+  letter-spacing: -0.015em;
 }
 
 a {

--- a/npm/tailwind.config.ts
+++ b/npm/tailwind.config.ts
@@ -23,7 +23,8 @@ const config: Config = {
         }
       },
       fontFamily: {
-        sans: ["var(--font-rubik)", ...defaultTheme.fontFamily.sans]
+        sans: ["var(--font-manrope)", ...defaultTheme.fontFamily.sans],
+        display: ["var(--font-sora)", "var(--font-manrope)", ...defaultTheme.fontFamily.sans]
       },
       boxShadow: {
         glow: "0 20px 50px rgba(125, 60, 255, 0.25)",

--- a/signupv2.html
+++ b/signupv2.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Crear cuenta — Gamification Journey</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;600;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&family=Sora:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/signupv2.css" />
 </head>
 <body class="signupv2">


### PR DESCRIPTION
## Summary
- swap the old Rubik/Inter stacks for new Sora (display) and Manrope (body) families across the public pages and dashboard
- update shared CSS tokens so headings, buttons, and key UI elements inherit the new typography and spacing
- align the Next.js layout and Tailwind config with the new font variables and adjust charts to render with Sora

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14cb9c840832294cde6aaa3d46b0b