### PR TITLE
Handle npm ci cache lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "preinstall": "node scripts/preinstall-clean.mjs",
     "test": "node --check refactor/js/features/formsintrov2.js",
     "db:schema": "node scripts/db-runner.mjs schema",
     "db:seeds": "node scripts/db-runner.mjs seeds",

--- a/scripts/preinstall-clean.mjs
+++ b/scripts/preinstall-clean.mjs
@@ -1,0 +1,33 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, "..");
+const cacheDir = path.join(projectRoot, "node_modules", ".cache");
+const MAX_RETRIES = 5;
+const RETRY_DELAY_MS = 200;
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeCacheDir() {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
+    try {
+      await fs.rm(cacheDir, { recursive: true, force: true });
+      if (attempt > 1) {
+        console.log(`preinstall: eliminado .cache tras ${attempt} intentos.`);
+      }
+      return;
+    } catch (error) {
+      if (error.code !== "EBUSY" || attempt === MAX_RETRIES) {
+        console.warn("preinstall: no se pudo limpiar node_modules/.cache", error);
+        return;
+      }
+      await sleep(RETRY_DELAY_MS * attempt);
+    }
+  }
+}
+
+await removeCacheDir();


### PR DESCRIPTION
## Summary
- add a preinstall hook that clears node_modules/.cache with retries to avoid EBUSY errors
- wire the cleanup script into npm scripts to run automatically before installs

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14e3899ac8322aae77aa42c4309ae