### PR TITLE
Avoid Next.js lockfile patching in offline environments

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -33,6 +33,9 @@ Para Neon, obtén la cadena de conexión en la consola y pégala en `DATABASE_UR
 - `npm run start`: Sirve la build de producción (ideal para Railway).
 - `npm run lint`: Ejecuta los chequeos de ESLint.
 
+> [!NOTE]
+> Todos los comandos anteriores delegan en `scripts/run-next.mjs`, que fuerza la variable de entorno `NEXT_IGNORE_INCORRECT_LOCKFILE` para evitar que Next.js intente "parchear" el `package-lock.json` cuando se trabaja sin conexión o detrás de proxys restringidos. Esto elimina las advertencias como `Found lockfile missing swc dependencies` y permite desarrollar sin fricciones en entornos offline o con políticas de red estrictas.
+
 ## Despliegue en Railway
 
 1. Crea un nuevo proyecto en Railway y sube este repositorio.

--- a/npm/package.json
+++ b/npm/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
+    "dev": "node ./scripts/run-next.mjs dev --turbo",
+    "build": "node ./scripts/run-next.mjs build",
+    "start": "node ./scripts/run-next.mjs start",
+    "lint": "node ./scripts/run-next.mjs lint"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.4",

--- a/npm/scripts/run-next.mjs
+++ b/npm/scripts/run-next.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+if (!process.env.NEXT_IGNORE_INCORRECT_LOCKFILE) {
+  process.env.NEXT_IGNORE_INCORRECT_LOCKFILE = '1';
+}
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  console.error('Usage: node scripts/run-next.mjs <command> [...args]');
+  process.exit(1);
+}
+
+const [command, ...commandArgs] = args;
+
+const child = spawn('next', [command, ...commandArgs], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32'
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});
+
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add a reusable Node runner that sets NEXT_IGNORE_INCORRECT_LOCKFILE before invoking the Next.js CLI
- update all npm scripts to execute through the new runner so offline environments avoid lockfile patch attempts
- document the change in the Next.js README to explain the absence of the warning

## Testing
- npm run lint
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e15606c6848322a50bcc060f38d086