### PR TITLE
Silence Clerk middleware warnings for static assets

### DIFF
--- a/npm/middleware.ts
+++ b/npm/middleware.ts
@@ -1,9 +1,15 @@
 import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
-  publicRoutes: ["/", "/api/health", "/sign-in(.*)", "/sign-up(.*)"]
+  publicRoutes: ["/", "/api/health", "/sign-in(.*)", "/sign-up(.*)"],
+  ignoredRoutes: [
+    // Skip static assets so Clerk does not log warnings about skipped middleware
+    "/((?!api|trpc).*)\\..+",
+    "/_next/:path*",
+    "/images/:path*"
+  ]
 });
 
 export const config = {
-  matcher: ["/((?!.+\.[\w]+$|_next).*)", "/", "/(api|trpc)(.*)"]
+  matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"]
 };


### PR DESCRIPTION
## Summary
- skip Clerk middleware execution for static assets and Next internals by extending ignored routes
- document the intent so repeated warnings about static file requests are avoided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e158ae5058832296b53f9575ba6e60