### PR TITLE
Fix middleware ignored routes regex error

### DIFF
--- a/npm/middleware.ts
+++ b/npm/middleware.ts
@@ -2,12 +2,7 @@ import { authMiddleware } from "@clerk/nextjs/server";
 
 export default authMiddleware({
   publicRoutes: ["/", "/api/health", "/sign-in(.*)", "/sign-up(.*)"],
-  ignoredRoutes: [
-    // Skip static assets so Clerk does not log warnings about skipped middleware
-    "/((?!api|trpc).*)\\..+",
-    "/_next/:path*",
-    "/images/:path*"
-  ]
+  ignoredRoutes: ["/_next/:path*", "/images/:path*"]
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
- remove the problematic Clerk middleware ignored route that triggered path-to-regexp parsing errors
- keep the _next and image exclusions so middleware still skips static assets

## Testing
- npm run lint *(fails: spawn next ENOENT because the Next.js binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15d6666708322a08ce9ae2424f17e