### PR TITLE
Increase Daily Energy bar thickness

### DIFF
--- a/css/dashboardv3.css
+++ b/css/dashboardv3.css
@@ -374,7 +374,7 @@ canvas{width:100% !important;height:auto !important;border-radius:10px}
 
 .energy-track{
   position: relative;
-  height: 15px;                     /* más finita */
+  height: 30px;                     /* el doble de alta para mayor presencia */
   border-radius: 999px;
   background: #2b2f3f;              /* track oscuro alineado al dashboard */
   border: 1px solid rgba(255,255,255,.10);

--- a/refactor/css/dashboardv3.css
+++ b/refactor/css/dashboardv3.css
@@ -363,7 +363,7 @@ canvas{width:100% !important;height:auto !important;border-radius:10px}
 
 .energy-track{
   position: relative;
-  height: 15px;                     /* más finita */
+  height: 30px;                     /* el doble de alta para mayor presencia */
   border-radius: 999px;
   background: #2b2f3f;              /* track oscuro alineado al dashboard */
   border: 1px solid rgba(255,255,255,.10);


### PR DESCRIPTION
## Summary
- double the height of the Daily Energy progress bars for better prominence
- keep both main and refactor stylesheets in sync with the new bar thickness

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e67f97d0948322b642d366c5b1f3f3